### PR TITLE
Add pyhf to listed projects

### DIFF
--- a/_data/projects/statistics/pyhf.yml
+++ b/_data/projects/statistics/pyhf.yml
@@ -1,0 +1,7 @@
+name: pyhf
+description: pure-Python implementation of HistFactory models.
+url: https://github.com/scikit-hep/pyhf
+readme: https://github.com/scikit-hep/pyhf/blob/master/README.md
+# docs: <url>
+# affiliated: set to true for affiliated packages
+# repo: only if different from url


### PR DESCRIPTION
Add [pyhf](https://github.com/scikit-hep/pyhf) to list of ~~scikit-hep~~ Scikit-HEP projects under "statistics" (as I didn't think it was worth making a separate category for "probabilistic modeling" at the moment).

cc @kratsg @lukasheinrich 