### PR TITLE
Restyle and add badges

### DIFF
--- a/_data/projects/basic/awkward-array.yml
+++ b/_data/projects/basic/awkward-array.yml
@@ -6,3 +6,6 @@ readme: https://github.com/scikit-hep/awkward-array/blob/master/README.rst
 # docs: <url>
 # affiliated: set to true for affiliated packages
 # repo: only if different from url
+badges:
+  pypi: awkward
+  conda-forge: awkward

--- a/_data/projects/basic/hepunits.yml
+++ b/_data/projects/basic/hepunits.yml
@@ -5,3 +5,6 @@ readme: https://github.com/scikit-hep/hepunits/blob/master/README.rst
 # docs: <url>
 # affiliated: set to true for affiliated packages
 # repo: only if different from url
+badges:
+  pypi: hepunits
+

--- a/_data/projects/fitting/goofit.yml
+++ b/_data/projects/fitting/goofit.yml
@@ -1,5 +1,6 @@
 name: GooFit
 projlogo: /assets/images/projlogo/logo_goofit.png
+projlogo-style: height:72px;
 description: GPU/OpenMP fitting in Python and C++.
 url: https://github.com/GooFit/GooFit
 readme: https://github.com/GooFit/GooFit/blob/master/README.md
@@ -11,3 +12,6 @@ longdescription: |
     [GooFit] is a powerful, fast fitting library designed to mimic the familiar syntax of [ROOT](https://root.cern.ch)'s [RooFit](http://roofit.sourceforge.net). The code and installation instructions are [available here, on GitHub][GooFit], and a description of the fitting process and API is available on [GitHub IO](https://GooFit.github.io/GooFit).
 
     [GooFit]:            https://github.com/GooFit/GooFit
+badges:
+  pypi: goofit
+

--- a/_data/projects/fitting/iminuit.yml
+++ b/_data/projects/fitting/iminuit.yml
@@ -5,3 +5,7 @@ readme: https://github.com/scikit-hep/iminuit/blob/master/README.rst
 docs: https://iminuit.readthedocs.io/
 # affiliated: set to true for affiliated packages
 # repo: only if different from url
+badges:
+  pypi: iminuit
+  conda-forge: iminuit
+

--- a/_data/projects/fitting/probfit.yml
+++ b/_data/projects/fitting/probfit.yml
@@ -5,3 +5,6 @@ readme: https://github.com/scikit-hep/probfit/blob/master/README.rst
 docs: https://probfit.readthedocs.io/
 # affiliated: set to true for affiliated packages
 # repo: only if different from url
+badges:
+  pypi: probfit
+

--- a/_data/projects/fitting/zfit.yml
+++ b/_data/projects/fitting/zfit.yml
@@ -18,3 +18,6 @@ longdescription: |
     [ROOT]: https://root.cern.ch/
     [Minuit]: https://seal.web.cern.ch/seal/snapshot/work-packages/mathlibs/minuit/
     [TensorFlow]: https://www.tensorflow.org/
+badges:
+  pypi: zfit
+

--- a/_data/projects/histogramming/aghast.yml
+++ b/_data/projects/histogramming/aghast.yml
@@ -6,3 +6,6 @@ readme: https://github.com/scikit-hep/aghast/blob/master/README.md
 # docs: https://aghast.readthedocs.io/
 # affiliated: set to true for affiliated packages
 # repo: only if different from url
+badges:
+  pypi: aghast
+

--- a/_data/projects/histogramming/boost-histogram.yml
+++ b/_data/projects/histogramming/boost-histogram.yml
@@ -1,8 +1,13 @@
 name: boost-histogram
 projlogo: /assets/images/projlogo/logo_boost_histogram.png
+projlogo-style: height:72px;
 description: Python bindings for the C++14 Boost::Histogram library.
 url: https://github.com/scikit-hep/boost-histogram
 readme: https://github.com/scikit-hep/boost-histogram/blob/develop/README.md
 docs: https://boost-histogram.readthedocs.io/en/latest/
 # affiliated: set to true for affiliated packages
 # repo: only if different from url
+badges:
+  pypi: boost-histogram
+  conda-forge: boost-histogram
+

--- a/_data/projects/histogramming/histbook.yml
+++ b/_data/projects/histogramming/histbook.yml
@@ -6,3 +6,6 @@ readme: https://github.com/scikit-hep/histbook/blob/master/README.rst
 docs: https://histbook.readthedocs.io/
 # affiliated: set to true for affiliated packages
 # repo: only if different from url
+badges:
+  pypi: histbook
+

--- a/_data/projects/interface/numpythia.yml
+++ b/_data/projects/interface/numpythia.yml
@@ -5,3 +5,6 @@ readme: https://github.com/scikit-hep/numpythia/blob/master/README.rst
 # docs: <url>
 # affiliated: set to true for affiliated packages
 # repo: only if different from url
+badges:
+  pypi: numpythia
+

--- a/_data/projects/interface/pyhepmc.yml
+++ b/_data/projects/interface/pyhepmc.yml
@@ -5,3 +5,6 @@ readme: https://github.com/scikit-hep/pyhepmc/blob/master/README.md
 # docs: <url>
 # affiliated: set to true for affiliated packages
 # repo: only if different from url
+badges:
+  pypi: pyhepmc
+

--- a/_data/projects/interface/pyjet.yml
+++ b/_data/projects/interface/pyjet.yml
@@ -5,3 +5,6 @@ readme: https://github.com/scikit-hep/pyjet/blob/master/README.rst
 # docs: <url>
 # affiliated: set to true for affiliated packages
 # repo: only if different from url
+badges:
+  pypi: pyjet
+

--- a/_data/projects/manipulation/formulate.yml
+++ b/_data/projects/manipulation/formulate.yml
@@ -5,3 +5,6 @@ readme: https://github.com/scikit-hep/formulate/blob/master/README.rst
 # docs: <url>
 # affiliated: set to true for affiliated packages
 # repo: only if different from url
+badges:
+  pypi: formulate
+

--- a/_data/projects/manipulation/root-numpy.yml
+++ b/_data/projects/manipulation/root-numpy.yml
@@ -5,3 +5,6 @@ readme: https://github.com/scikit-hep/root_numpy/blob/master/README.rst
 docs: http://scikit-hep.org/root_numpy/
 # affiliated: set to true for affiliated packages
 # repo: only if different from url
+badges:
+  pypi: root-numpy
+

--- a/_data/projects/manipulation/root-pandas.yml
+++ b/_data/projects/manipulation/root-pandas.yml
@@ -5,3 +5,6 @@ readme: https://github.com/scikit-hep/root_pandas/blob/master/README.md
 # docs: <url>
 # affiliated: set to true for affiliated packages
 # repo: only if different from url
+badges:
+  pypi: root-pandas
+

--- a/_data/projects/manipulation/uproot-methods.yml
+++ b/_data/projects/manipulation/uproot-methods.yml
@@ -5,3 +5,6 @@ readme: https://github.com/scikit-hep/uproot-methods/blob/master/README.rst
 # docs: <url>
 # affiliated: set to true for affiliated packages
 # repo: only if different from url
+badges:
+  pypi: uproot-methods
+

--- a/_data/projects/manipulation/uproot.yml
+++ b/_data/projects/manipulation/uproot.yml
@@ -6,3 +6,7 @@ readme: https://github.com/scikit-hep/uproot/blob/master/README.rst
 docs: https://uproot.readthedocs.io/
 # affiliated: set to true for affiliated packages
 # repo: only if different from url
+badges:
+  pypi: uproot
+  conda-forge: uproot
+

--- a/_data/projects/misc/conda-forge-root.yml
+++ b/_data/projects/misc/conda-forge-root.yml
@@ -40,3 +40,6 @@ longdescription: |
     [miniconda]:      https://docs.conda.io/en/latest/miniconda.html
     [Conda-Forge]:    https://conda-forge.org
     [binder]:         https://mybinder.org
+
+badges:
+  conda-forge: root

--- a/_data/projects/misc/scikit-hep-testdata.yml
+++ b/_data/projects/misc/scikit-hep-testdata.yml
@@ -5,3 +5,5 @@ readme: https://github.com/scikit-hep/scikit-hep-testdata/blob/master/README.md
 # docs: <url>
 # affiliated: set to true for affiliated packages
 # repo: only if different from url
+badges:
+  pypi: scikit-hep-testdata

--- a/_data/projects/misc/scikit-hep.yml
+++ b/_data/projects/misc/scikit-hep.yml
@@ -5,3 +5,5 @@ readme: https://github.com/scikit-hep/scikit-hep/blob/master/README.rst
 # docs: <url>
 # affiliated: set to true for affiliated packages
 # repo: only if different from url
+badges:
+  pypi: scikit-hep

--- a/_data/projects/particle/decaylanguage.yml
+++ b/_data/projects/particle/decaylanguage.yml
@@ -6,3 +6,6 @@ readme: https://github.com/scikit-hep/decaylanguage/blob/master/README.md
 docs: https://decaylanguage.readthedocs.io/
 # affiliated: set to true for affiliated packages
 # repo: only if different from url
+badges:
+  pypi: decaylanguage
+

--- a/_data/projects/particle/particle.yml
+++ b/_data/projects/particle/particle.yml
@@ -6,3 +6,6 @@ readme: https://github.com/scikit-hep/particle/blob/master/README.rst
 # docs: <url>
 # affiliated: set to true for affiliated packages
 # repo: only if different from url
+badges:
+  pypi: Particle
+

--- a/_data/projects/statistics/hepstats.yml
+++ b/_data/projects/statistics/hepstats.yml
@@ -5,3 +5,6 @@ readme: https://github.com/scikit-hep/hepstats/blob/master/README.md
 # docs: <url>
 # affiliated: set to true for affiliated packages
 # repo: only if different from url
+badges:
+  pypi: hepstats
+

--- a/_data/projects/statistics/pyhf.yml
+++ b/_data/projects/statistics/pyhf.yml
@@ -1,8 +1,12 @@
 name: pyhf
 projlogo: /assets/images/projlogo/logo_pyhf.png
+projlogo-style: height:96px;
 description: pure-Python implementation of HistFactory models.
 url: https://github.com/scikit-hep/pyhf
 readme: https://github.com/scikit-hep/pyhf/blob/master/README.md
 docs: https://scikit-hep.org/pyhf/
 # affiliated: set to true for affiliated packages
 # repo: only if different from url
+badges:
+  pypi: pyhf
+

--- a/_data/projects/visualization/mplhep.yml
+++ b/_data/projects/visualization/mplhep.yml
@@ -1,8 +1,12 @@
 name: mplhep
 projlogo: /assets/images/projlogo/logo_mplhep.png
+projlogo-style: height:72px;
 description: Plotting and styling helpers for matplotlib.
 url: https://github.com/scikit-hep/mplhep
 readme: https://github.com/scikit-hep/mplhep/blob/master/README.md
 # docs: <url>
 # affiliated: set to true for affiliated packages
 # repo: only if different from url
+badges:
+  pypi: mplhep
+

--- a/_data/projects/visualization/vegascope.yml
+++ b/_data/projects/visualization/vegascope.yml
@@ -5,3 +5,5 @@ readme: https://github.com/scikit-hep/vegascope/blob/master/README.rst
 # docs: <url>
 # affiliated: set to true for affiliated packages
 # repo: only if different from url
+badges:
+  pypi: vegascope

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -1,6 +1,10 @@
 $link-color: #7092be;
 
-li.affiliated em {
+em.affiliated {
   color: #ff6347;
 }
 
+a.package {
+  font-size: larger;
+  font-weight: bold;
+}

--- a/index.md
+++ b/index.md
@@ -4,8 +4,7 @@ title: Home
 nav_order: 1
 ---
 
-Scikit-HEP project - welcome!
-=============================
+# Scikit-HEP project - welcome!
 
 The Scikit-HEP project is a community-driven and
 community-oriented project with the aim of providing Particle Physics at
@@ -32,26 +31,47 @@ physicist\'s work. These are:
 - **Visualization**: interface to graphics engines, from ROOT and
   Matplotlib to even beyond.
 
-Toolset packages {#index_toolset_packages}
-----------------
+# Toolset packages {#index_toolset_packages}
 
 To get started, have a look at our [GitHub repository][]. The list of presently available packages follows, together with a very
 short description of their goals:
 
 {% for cat in site.data.categories -%}
-{%- assign listing = site.data.projects[cat.name] | sort -%}
-### {{cat.title}}:
+{%-  assign listing = site.data.projects[cat.name] | sort -%}
+## {{cat.title}}:
 
-{% for item in listing -%}
-{%- assign project = item[1] -%}
-{%- if project.affiliated -%}
-- {:.affiliated} [{{project.name}}]({{project.url}}): {{project.description}} 🤝 *Affiliated package* 
-{%- else -%}
-- [{{project.name}}]({{project.url}}): {{project.description}}
-{%- endif %} {% if project.projlogo -%}
-![{{project.name}} logo]({{site.baseurl}}{{ project.projlogo | link }}){: style="height:24px"}
-{%- endif %}
-{% endfor %}
+{%   for item in listing -%}
+{%-    assign project = item[1] -%}
+{%-    if project.projlogo -%}
+{{" "}}[![{{project.name}} logo]({{site.baseurl}}{{ project.projlogo | link }}){: style="{{ project.projlogo-style | default: "height:48px;"}}"}]({{project.url}}){:.logo}<br/>{{" "}}
+{%-    endif -%}
+[{{project.name}}]({{project.url}}){:.package}
+ :
+    {{" "}}{{project.description}}
+{%-    if project.badges -%}
+<br/>{{" "}}
+{%-      if project.badges.pypi -%}
+           {{" "}}[![PyPI](https://img.shields.io/pypi/v/{{project.badges.pypi}}?color=blue&logo=PyPI&logoColor=white)](https://pypi.org/project/{{project.badges.pypi}}/){:.badge}
+{%-      endif -%}
+{%-      if project.badges.conda-forge -%}
+           {{" "}}[![PyPI](https://img.shields.io/conda/vn/conda-forge/{{project.badges.conda-forge}}.svg?logo=Conda-Forge&color=green&logoColor=white)](https://github.com/conda-forge/{{project.badges.conda-forge}}/){:.badge}
+{%-      endif -%}
+{%-    endif -%}
+{%-    if project.affiliated -%}
+         {{" "}}🤝 *Affiliated package*{:.affiliated} 
+{%-    endif %}
+
+{%   endfor %}
+
+---
+
+{::comment} Badge fury instead:
+           {{" "}}[![PyPI](https://badge.fury.io/py/{{project.badges.pypi}}.svg)](https://pypi.org/project/{{project.badges.pypi}}/){:.badge}
+           Add these for interesting info:
+           {{" "}}[![PyPI](https://img.shields.io/pypi/wheel/{{project.badges.pypi}})](https://pypi.org/project/{{project.badges.pypi}}/){:.badge}
+           {{" "}}[![PyPI](https://img.shields.io/pypi/pyversions/{{project.badges.pypi}})](https://pypi.org/project/{{project.badges.pypi}}/){:.badge}
+           {{" "}}[![PyPI](https://img.shields.io/pypi/status/{{project.badges.pypi}})](https://pypi.org/project/{{project.badges.pypi}}/){:.badge}
+{:/comment}
 
 {% endfor %}
 


### PR DESCRIPTION
Styling changed on the front page, and added project badges. Example:

<img width="775" alt="Screen Shot 2020-01-07 at 5 32 53 PM" src="https://user-images.githubusercontent.com/4616906/71935032-cab3c300-3173-11ea-96b5-be4014467a73.png">

I could add Python version, Wheel available, and/or project status if we properly supported those across all projects.