### PR TITLE
Fixing Conda-forge links

### DIFF
--- a/_data/projects/fitting/goofit.yml
+++ b/_data/projects/fitting/goofit.yml
@@ -8,6 +8,7 @@ docs: https://goofit.github.io
 affiliated: true
 # repo: only if different from url
 image: /assets/images/projusers/logo_goofit.png
+image-style: height:96px;
 longdescription: |
     [GooFit] is a powerful, fast fitting library designed to mimic the familiar syntax of [ROOT](https://root.cern.ch)'s [RooFit](http://roofit.sourceforge.net). The code and installation instructions are [available here, on GitHub][GooFit], and a description of the fitting process and API is available on [GitHub IO](https://GooFit.github.io/GooFit).
 

--- a/_data/projects/fitting/goofit.yml
+++ b/_data/projects/fitting/goofit.yml
@@ -15,4 +15,5 @@ longdescription: |
 badges:
   pypi: goofit
   conda-forge: goofit
+  conda-forge-feedstock: goofit-split
 

--- a/index.md
+++ b/index.md
@@ -51,10 +51,10 @@ short description of their goals:
 {%-    if project.badges -%}
 <br/>{{" "}}
 {%-      if project.badges.pypi -%}
-           {{" "}}[![PyPI](https://img.shields.io/pypi/v/{{project.badges.pypi}}?color=blue&logo=PyPI&logoColor=white)](https://pypi.org/project/{{project.badges.pypi}}/){:.badge}
+           {{" "}}[![PyPI](https://img.shields.io/pypi/v/{{project.badges.pypi}}?color=blue&logo=PyPI&logoColor=white)](https://pypi.org/project/{{project.badges.pypi}}){:.badge}
 {%-      endif -%}
 {%-      if project.badges.conda-forge -%}
-           {{" "}}[![PyPI](https://img.shields.io/conda/vn/conda-forge/{{project.badges.conda-forge}}.svg?logo=Conda-Forge&color=green&logoColor=white)](https://github.com/conda-forge/{{project.badges.conda-forge}}/){:.badge}
+           {{" "}}[![PyPI](https://img.shields.io/conda/vn/conda-forge/{{ project.badges.conda-forge}}.svg?logo=Conda-Forge&color=green&logoColor=white)](https://github.com/conda-forge/{{ project.badges.conda-forge-feedstock | default: project.badges.conda-forge}}-feedstock){:.badge}
 {%-      endif -%}
 {%-    endif -%}
 {%-    if project.affiliated -%}

--- a/pages/affiliated.md
+++ b/pages/affiliated.md
@@ -17,7 +17,7 @@ In the following, projects that work closely together with Scikit-HEP are descri
 {%- if project.affiliated -%}
 {%- if project.image -%}
 ---
-[![{{project.name}} logo]({{site.baseurl}}{{ project.image | link }})]({{project.url}}){:.largelogo}
+[![{{project.name}} logo]({{site.baseurl}}{{ project.image | link }}){: style="{{ project.image-style | default: "height:64px;"}}"}]({{project.url}}){: .largelogo }
 {%- else -%}
 ---
 {%- endif %}


### PR DESCRIPTION
The conda forge link for GooFit was broken, and in fixing that I realized all Conda-forge links were broken. This fixes them.