### PR TITLE
Promote iminuit from affiliated

### DIFF
--- a/_data/projects/fitting/iminuit.yml
+++ b/_data/projects/fitting/iminuit.yml
@@ -4,10 +4,8 @@ url: https://github.com/scikit-hep/iminuit
 readme: https://github.com/scikit-hep/iminuit/blob/master/README.rst
 docs: https://iminuit.readthedocs.io/
 projlogo: /assets/images/projlogo/logo_iminuit.png
-affiliated: true
 # affiliated: set to true for affiliated packages
 # repo: only if different from url
 badges:
   pypi: iminuit
   conda-forge: iminuit
-


### PR DESCRIPTION
As iminuit is a Scikit-HEP package, and no longer just affiliated, then it should be updated on the pages as well.