### PR TITLE
Break up GHA

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -5,7 +5,7 @@
     {%- assign pages_list = site.html_pages | sort:"nav_order" -%}
     {%- for node in pages_list -%}
       {%- unless node.nav_exclude -%}
-        {%- if node.parent == nil -%}
+        {%- if node.parent == nil and node.title -%}
           <li class="navigation-list-item{% if page.url == node.url or page.parent == node.title or page.grand_parent == node.title %} active{% endif %}">
             {%- if page.parent == node.title or page.grand_parent == node.title -%}
               {%- assign first_level_url = node.url | absolute_url -%}

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -47,3 +47,16 @@ div.project .description {
 div.description .inner p {
   display: inline;
 }
+
+nav > ul.navigation-list {
+  list-style-type: none;
+  padding-inline-start: 12px;
+}
+
+nav > ul.navigation-list > li > ul {
+  padding-inline-start: 24px;
+}
+
+nav > ul.navigation-list li.active > a {
+  font-weight: bold;
+}

--- a/pages/developers/badges.md
+++ b/pages/developers/badges.md
@@ -2,7 +2,7 @@
 layout: page
 title: Badges
 permalink: /badges
-nav_order: 9
+nav_order: 12
 parent: Developer information
 ---
 

--- a/pages/developers/gha_basic.md
+++ b/pages/developers/gha_basic.md
@@ -30,19 +30,15 @@ on:
   push:
     branches:
     - master
-  release:
-    types:
-    - published
 
 jobs:
 ```
 
 This gives the workflow a nice name, and defines the conditions under which it
-runs. This will run on all pull requests, or pushes to master, and on GitHub
-releases. If you use a develop branch, you probably will want to include that.
-If you want tags instead of releases, you can add the `on: push: tags: "v*"`
-key instead of the releases. You can also specify specific branches for pull
-requests.
+runs. This will run on all pull requests, or pushes to master. If you use a
+develop branch, you probably will want to include that.  You can also specify
+specific branches for pull requests instead of running on all PRs (will run on
+PRs targeting those branches only).
 
 ## Pre-commit
 
@@ -119,90 +115,6 @@ The formula here for installing should be identical for all users; and using
 [PEP 517](https://www.python.org/dev/peps/pep-0517/)/[518](https://www.python.org/dev/peps/pep-0518/)
 builds, you are even guaranteed a consistent wheel will be produced just as if
 you were building a final package.
-
-## Distribution: Pure Python wheels
-
-We will cover binary wheels later, but for a simple universal (pure Python)
-package, the procedure is simple.
-
-{% raw %}
-```yaml
-  dist:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-python@v1
-      with:
-        python-version: 3.8
-
-    - name: Install wheel and SDist requirements
-      run: python -m pip install "setuptools>=42.0" "setuptools_scm[toml]>=4.1" "wheel" "twine"
-
-    - name: Build SDist
-      run: python setup.py sdist
-
-    - uses: actions/upload-artifact@v2
-      with:
-        path: dist/*
-
-    - name: Build wheel
-      run: >
-        python -m pip wheel . -w wheels
-
-    - uses: actions/upload-artifact@v2
-      with:
-        path: wheels/<packagename>*.whl
-
-    - name: Check metadata
-      run: twine check dist/* wheels/*
-
-```
-{% endraw %}
-
-A few things to note that are new to this job:
-
-We install SDist requirements by hand since `python setup.py sdist` does not
-get the benefits of having pip install things. If you have any special
-requirements in your `pyproject.toml`, you'll need to list them here. This is
-special just for the SDist, not for making wheels (which should be done by the
-PEP 517/518 process for you).
-
-You need to put your base package name in for `<packagename>` in the upload
-command; pip will put all wheels needed in the directory you specify, and you
-need to just pick out your wheels for upload. You don't want to upload NumPy or
-some other wheel it had to build (not common anymore, but can happen).
-
-We upload the artifact just to make it available via the GitHub PR/Checks API.
-You can download a file to test locally if you want without making a release.
-
-We also add an optional check using twine for the metadata (it will be tested
-later in the upload action for the release job, as well).
-
-And then, you need a release job:
-
-{% raw %}
-```yaml
-  publish:
-    needs: [dist]
-    runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'published'
-
-    steps:
-    - uses: actions/download-artifact@v2
-      with:
-        name: artifact
-        path: dist
-
-    - uses: pypa/gh-action-pypi-publish@v1.2.2
-      with:
-        user: __token__
-        password: ${{ secrets.pypi_password }}
-```
-{% endraw %}
-
-When you make a GitHub release in the web UI, we publish to PyPI. You'll need
-to go to PyPI, generate a token for your project, and put it into
-`pypi_password` on your repo's secrets page.
 
 ## Advanced: Testing against the latest development Python
 

--- a/pages/developers/gha_basic.md
+++ b/pages/developers/gha_basic.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: GitHub Actions
+title: "GHA: GitHub Actions intro"
 permalink: /developer/gha_basic
 nav_order: 7
 parent: Developer information

--- a/pages/developers/gha_pure.md
+++ b/pages/developers/gha_pure.md
@@ -1,0 +1,144 @@
+
+---
+layout: page
+title: GitHub Actions for pure Wheels
+permalink: /developer/gha_pure
+nav_order: 8
+parent: Developer information
+---
+
+
+
+We will cover binary wheels [on the next page][], but if you do not have a compiled
+extension, this is called a universal (pure Python) package, and the procedure
+to make a "built" wheel is simple.
+
+> Note: Why make a wheel when there is nothing to compile? There are a multitude of reasons
+> that a wheel is better than only providing an sdist:
+>
+> * Wheels do not run setup.py, but simply install files into locations
+>   - Lower install requirements - users don't need your setup tools
+>   - Faster installs
+>   - Safer installs - no arbitrary code execution
+>   - Highly consistent installs
+> * Wheels pre-compile bytecode when they install
+>   - Initial import is not slower than subsequent import
+>   - Less chance of a permission issue
+> * You can look in the `.whl` (it's a `.tar.gz`, really) and see where everything is going to go
+
+
+[on the next page]: {{ site.baseurl }}{% link pages/developers/gha_wheels.md %}
+
+## Job setup
+
+```yaml
+name: CD
+
+on:
+  workflow_dispatch:
+  release:
+    types:
+    - published
+
+jobs:
+
+```
+
+This will run when you manually trigger a build ([`workflow_dispatch`][]), or
+when you publish a release. Later, we will make sure that the actual publish
+step requires the event to be a publish event, so that manual triggers (and
+branches/PRs, if those are enabled).
+
+If you want tags instead of releases, you can add the `on: push: tags: "v*"`
+key instead of the releases - however, *please* remember to make a GitHub
+release of your tag! It shows up in the GUI and it notifies anyone watching
+releases(-only). You will also need to change the event filter below.
+
+You can merge the CI job and the CD job if you want. To do that, preferably
+with the name "CI/CD", you can just combine the two `on` dicts.
+
+[`workflow_dispatch`]: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
+
+## Distribution: Pure Python wheels
+
+
+{% raw %}
+```yaml
+  dist:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Install wheel and SDist requirements
+      run: python -m pip install "setuptools>=42.0" "setuptools_scm[toml]>=4.1" "wheel" "twine"
+
+    - name: Build SDist
+      run: python setup.py sdist
+
+    - uses: actions/upload-artifact@v2
+      with:
+        path: dist/*
+
+    - name: Build wheel
+      run: >
+        python -m pip wheel . -w wheels
+
+    - uses: actions/upload-artifact@v2
+      with:
+        path: wheels/<packagename>*.whl
+
+    - name: Check metadata
+      run: twine check dist/* wheels/*
+
+```
+{% endraw %}
+
+A few things to note that are new to this job:
+
+We install SDist requirements by hand since `python setup.py sdist` does not
+get the benefits of having pip install things. If you have any special
+requirements in your `pyproject.toml`, you'll need to list them here. This is
+special just for the SDist, not for making wheels (which should be done by the
+PEP 517/518 process for you).
+
+You need to put your base package name in for `<packagename>` in the upload
+command; pip will put all wheels needed in the directory you specify, and you
+need to just pick out your wheels for upload. You don't want to upload NumPy or
+some other wheel it had to build (not common anymore, but can happen).
+
+> You can also use `pep518.build` here instead of pip.
+
+We upload the artifact just to make it available via the GitHub PR/Checks API.
+You can download a file to test locally if you want without making a release.
+
+We also add an optional check using twine for the metadata (it will be tested
+later in the upload action for the release job, as well).
+
+And then, you need a release job:
+
+{% raw %}
+```yaml
+  publish:
+    needs: [dist]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+
+    steps:
+    - uses: actions/download-artifact@v2
+      with:
+        name: artifact
+        path: dist
+
+    - uses: pypa/gh-action-pypi-publish@v1.2.2
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_password }}
+```
+{% endraw %}
+
+When you make a GitHub release in the web UI, we publish to PyPI. You'll need
+to go to PyPI, generate a token for your project, and put it into
+`pypi_password` on your repo's secrets page.

--- a/pages/developers/gha_pure.md
+++ b/pages/developers/gha_pure.md
@@ -1,7 +1,6 @@
-
 ---
 layout: page
-title: GitHub Actions for pure Wheels
+title: "GHA: Pure Python wheels"
 permalink: /developer/gha_pure
 nav_order: 8
 parent: Developer information

--- a/pages/developers/gha_wheels.md
+++ b/pages/developers/gha_wheels.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: GitHub Actions for Binary Wheels
+title: "GHA: Binary wheels"
 permalink: /developer/gha_wheels
 nav_order: 9
 parent: Developer information

--- a/pages/developers/gha_wheels.md
+++ b/pages/developers/gha_wheels.md
@@ -2,7 +2,7 @@
 layout: page
 title: GitHub Actions for Binary Wheels
 permalink: /developer/gha_wheels
-nav_order: 8
+nav_order: 9
 parent: Developer information
 ---
 

--- a/pages/developers/guidelines.md
+++ b/pages/developers/guidelines.md
@@ -1,12 +1,12 @@
 ---
 layout: page
-title: New package guidelines
+title: Package requirements
 permalink: /developer/guidelines
 nav_order: 1
 parent: Developer information
 ---
 
-# New package requirements and guidelines
+# Package requirements and guidelines
 
 The guidelines on this page provide minimum requirements for Scikit-HEP
 packages, which we hope help providing high-quality packages with some level of

--- a/pages/developers/guidelines.md
+++ b/pages/developers/guidelines.md
@@ -1,12 +1,12 @@
 ---
 layout: page
-title: Package requirements and guidelines
+title: New package guidelines
 permalink: /developer/guidelines
 nav_order: 1
 parent: Developer information
 ---
 
-# Package requirements and guidelines
+# New package requirements and guidelines
 
 The guidelines on this page provide minimum requirements for Scikit-HEP
 packages, which we hope help providing high-quality packages with some level of

--- a/pages/developers/index.md
+++ b/pages/developers/index.md
@@ -9,9 +9,27 @@ has_children: true
 Developer Information
 =====================
 
-The pages here are intended for developers who are making or maintaining a package,
+The pages here are intended for developers who [are making][guidelines] or maintaining a package,
 especially one that is part of Scikit-HEP or being proposed to become part.
 
-New developers are encouraged to read the following guidelines starting at the
-guidelines and introduction. Veteran developers should still check out introduction on the
-first page, as it has a guide on recommendations for your `CONTRIBUTING.md`.
+New developers are encouraged to read the following pages.
+Veteran developers should still check out [introduction][intro], as it has a guide on recommendations for your `CONTRIBUTING.md`.
+
+Following that, there are recommendations for [style][], intended to promote
+good practices and to ensure continuity across the packages.  There is then a
+guide on [packaging][], which should help in ensuring a consistent developer
+and user experience when working with distribution.
+
+A section on CI follows, with a [general setup guide][gha_basic], and then two choices for using CI to distribute
+your package, on for [pure Python][gha_pure], and one for [compiled extensions][gha_wheels].
+
+Finally, there are [badge recommendations][badges] for your readme, including the Scikit-HEP badge!
+
+[guidelines]: {{ site.baseurl }}{% link pages/developers/guidelines.md %}
+[intro]: {{ site.baseurl }}{% link pages/developers/intro.md %}
+[style]: {{ site.baseurl }}{% link pages/developers/style.md %}
+[packaging]: {{ site.baseurl }}{% link pages/developers/packaging.md %}
+[gha_basic]: {{ site.baseurl }}{% link pages/developers/gha_basic.md %}
+[gha_pure]: {{ site.baseurl }}{% link pages/developers/gha_pure.md %}
+[gha_wheels]: {{ site.baseurl }}{% link pages/developers/gha_wheels.md %}
+[badges]: {{ site.baseurl }}{% link pages/developers/badges.md %}


### PR DESCRIPTION
This PR:
* Breaks up the GHA into better sections: intro (basic testing), pure Python wheels, and binary wheels. Some updates for recent improvements / experience.
* Makes the menu a little better (it seems to have changed recently, but don't see a commit for a change)
* Shortens a few menu items so it's easier to navigate.
* Adds a bit of text and crosslinks to the main developer page.