### PR TITLE
docs: Add pyhf Conda-forge badge

### DIFF
--- a/_data/projects/statistics/pyhf.yml
+++ b/_data/projects/statistics/pyhf.yml
@@ -9,4 +9,4 @@ docs: https://scikit-hep.org/pyhf/
 # repo: only if different from url
 badges:
   pypi: pyhf
-
+  conda-forge: pyhf

--- a/_data/projects/statistics/pyhf.yml
+++ b/_data/projects/statistics/pyhf.yml
@@ -3,7 +3,7 @@ projlogo: /assets/images/projlogo/logo_pyhf.png
 projlogo-style: height:96px;
 description: pure-Python implementation of HistFactory models.
 url: https://github.com/scikit-hep/pyhf
-readme: https://github.com/scikit-hep/pyhf/blob/master/README.md
+readme: https://github.com/scikit-hep/pyhf/blob/master/README.rst
 docs: https://scikit-hep.org/pyhf/
 # affiliated: set to true for affiliated packages
 # repo: only if different from url


### PR DESCRIPTION
Add the Conda-forge badge for `pyhf` and update the README link to reflect that `pyhf` now used RST.