### PR TITLE
fix: change recommendation to PyPA-Build

### DIFF
--- a/pages/developers/gha_basic.md
+++ b/pages/developers/gha_basic.md
@@ -78,7 +78,7 @@ OS's if you'd like by adding them to the matrix and inputting them into
         - 2.7
         - 3.6
         - 3.8
-        - 3.9-dev  # Optional!
+        - 3.9  # No Numba yet
     name: Check Python ${{ matrix.python-version }}
     steps:
     - uses: actions/checkout@v1

--- a/pages/developers/gha_pure.md
+++ b/pages/developers/gha_pure.md
@@ -73,70 +73,51 @@ with the name "CI/CD", you can just combine the two `on` dicts.
     - uses: actions/setup-python@v2
 
     - name: Install wheel and SDist requirements
-      run: python -m pip install "setuptools>=42.0" "setuptools_scm[toml]>=4.1" "wheel" "twine"
+      run: python -m pip install build
 
-    - name: Build SDist
-      run: python setup.py sdist
+    - name: Build SDist and wheel
+      run: python -m build
 
     - uses: actions/upload-artifact@v2
       with:
         path: dist/*
 
-    - name: Build wheel
-      run: >
-        python -m pip wheel . -w wheels
-
-    - uses: actions/upload-artifact@v2
-      with:
-        path: wheels/<packagename>-*.whl
-
     - name: Check metadata
-      run: twine check dist/* wheels/*
+      run: twine check dist/*
 
 ```
 {% endraw %}
 
-A few things to note that are new to this job:
-
-We install SDist requirements by hand since `python setup.py sdist` does not
-get the benefits of having pip install things. If you have any special
-requirements in your `pyproject.toml`, you'll need to list them here. This is
-special just for the SDist, not for making wheels (which should be done by the
-PEP 517/518 process for you).
-
-You need to put your base package name in for `<packagename>` in the upload
-command; pip will put all wheels needed in the directory you specify, and you
-need to just pick out your wheels for upload. You don't want to upload NumPy or
-some other wheel it had to build (not common anymore, but can happen).
-
-<details><summary>New, simpler build tool! (Click to expand)</summary>
-
-{%- capture "mymarkdown" -%}
-
-You can use [Python-Build](https://python-build.readthedocs.io/en/latest/), a
+We use [PyPA-Build](https://pypa-build.readthedocs.io/en/latest/), a
 new build tool designed to make building wheels and SDists easy. It run a [PEP
-517][] backend and can get [PEP 518][] requirements even for making SDists. To
-use it, all you need is:
+517][] backend and can get [PEP 518][] requirements even for making SDists.
 
-```python
-python -m pip install build # (optionally twine too, if you need to check/publish)
-```
-
-Then, you can just run:
-
-```python
-python -m build
-```
-
-And you will make an SDist and a wheel from the package in the current
+By default this will make an SDist and a wheel from the package in the current
 directory, and they will be placed in `./dist`. You can only build SDist
 (`-s`), only build wheel (`-w`), change the output folder (`-o <dir>`) or give
 a different input folder if you want.
 
-This will be moved to the recommended method in the page above [when it is
-accepted](https://github.com/FFY00/python-build/issues/42) as an official
-package by PyPA.
+<details><summary>Breaking up or classic SDist buils (Click to expand)</summary>
 
+{%- capture "mymarkdown" -%}
+
+If you don't have a pyproject.toml, you might need to use the raw `setup.py` commands.
+This is the classic way to do things, though you should consider direct usage of setup.py
+to be an implementation detail, and setup.py is not even required in modern packages.
+
+You must install SDist requirements by hand since `python setup.py sdist` does not
+get the benefits of having pip install things. If you have any special
+requirements in your `pyproject.toml` (and still don't want to use `build`),
+you'll need to list them. This is special just for the SDist, not for making wheels
+(which should be done by the PEP 517/518 process for you because you will use
+`build` or `pip`).
+
+To build the wheel, you can use `python -m pip wheel . -w wheelhouse`. Unlike build,
+this is a wheelhouse, not the output wheel; any wheels it makes during the process
+will be put here, not just the one you wanted to upload. Be sure to use something
+like `wheelhouse/my_package*.whl` when you pick your items from this folder so as
+not to pick a random dependency that didn't have a binary wheel already. Or just
+use PyPA-Build.
 
 {%- endcapture -%}
 

--- a/pages/developers/gha_wheels.md
+++ b/pages/developers/gha_wheels.md
@@ -69,16 +69,16 @@ before, will work:
     steps:
     - uses: actions/checkout@v1
       with:
-        submodules: true    # Optional if you have submodules
+        submodules: true  # Optional if you have submodules
 
     - name: Setup Python
       uses: actions/setup-python@v2
 
     - name: Install deps
-      run: python -m pip install "setuptools>=42" "setuptools_scm[toml]>=4.1.0"
+      run: python -m pip install build
 
     - name: Build SDist
-      run: python setup.py sdist
+      run: python -m build -s
 
     - uses: actions/upload-artifact@v2
       with:
@@ -110,7 +110,7 @@ The core of the work is down here:
       uses: actions/setup-python@v2
 
     - name: Install cibuildwheel
-      run: python -m pip install cibuildwheel==1.6.4
+      run: python -m pip install cibuildwheel==1.7.1
 
     - name: Build wheel
       run: python -m cibuildwheel --output-dir wheelhouse
@@ -180,7 +180,7 @@ If you have to support Python 2.7 on Windows, you can use a custom job:
     - uses: actions/setup-python@v2
 
     - name: Install cibuildwheel
-      run: python -m pip install cibuildwheel==1.6.4
+      run: python -m pip install cibuildwheel==1.7.1
 
     - uses: ilammy/msvc-dev-cmd@v1
 


### PR DESCRIPTION
This has now been accepted by the Python Packaging Authority, so let's make it the main recommendation, as we stated we would.