### PR TITLE
fix: update awkward links

### DIFF
--- a/_data/projects/basic/awkward-array.yml
+++ b/_data/projects/basic/awkward-array.yml
@@ -1,8 +1,8 @@
 name: awkward-array
 projlogo: /assets/images/projlogo/logo_awkward_array.png
 description: Manipulate arrays of complex data structures as easily as Numpy.
-url: https://github.com/scikit-hep/awkward-array
-readme: https://github.com/scikit-hep/awkward-array/blob/master/README.rst
+url: https://github.com/scikit-hep/awkward-array-1.0
+readme: https://github.com/scikit-hep/awkward-array-1.0/blob/master/README.rst
 # docs: <url>
 # affiliated: set to true for affiliated packages
 # repo: only if different from url

--- a/_data/projects/basic/awkward-array.yml
+++ b/_data/projects/basic/awkward-array.yml
@@ -1,8 +1,8 @@
 name: awkward-array
 projlogo: /assets/images/projlogo/logo_awkward_array.png
-description: Manipulate arrays of complex data structures as easily as Numpy.
+description: Manipulate JSON-like data with NumPy-like idioms.
 url: https://github.com/scikit-hep/awkward-1.0
-readme: https://github.com/scikit-hep/awkward-1.0/blob/main/README.rst
+readme: https://github.com/scikit-hep/awkward-1.0/blob/main/README.md
 docs: https://awkward-array.org
 badges:
   pypi: awkward

--- a/_data/projects/basic/awkward-array.yml
+++ b/_data/projects/basic/awkward-array.yml
@@ -1,11 +1,9 @@
 name: awkward-array
 projlogo: /assets/images/projlogo/logo_awkward_array.png
 description: Manipulate arrays of complex data structures as easily as Numpy.
-url: https://github.com/scikit-hep/awkward-array-1.0
-readme: https://github.com/scikit-hep/awkward-array-1.0/blob/master/README.rst
-# docs: <url>
-# affiliated: set to true for affiliated packages
-# repo: only if different from url
+url: https://github.com/scikit-hep/awkward-1.0
+readme: https://github.com/scikit-hep/awkward-1.0/blob/main/README.rst
+docs: https://awkward-array.org
 badges:
   pypi: awkward
   conda-forge: awkward

--- a/_data/projects/manipulation/uproot-methods.yml
+++ b/_data/projects/manipulation/uproot-methods.yml
@@ -5,6 +5,7 @@ readme: https://github.com/scikit-hep/uproot-methods/blob/master/README.rst
 # docs: <url>
 # affiliated: set to true for affiliated packages
 # repo: only if different from url
+deprecated: true
 badges:
   pypi: uproot-methods
   conda-forge: uproot-methods

--- a/_data/projects/manipulation/uproot.yml
+++ b/_data/projects/manipulation/uproot.yml
@@ -1,8 +1,8 @@
 name: uproot
 projlogo: /assets/images/projlogo/logo_uproot.png
 description: Minimalist ROOT I/O in pure Python and Numpy.
-url: https://github.com/scikit-hep/uproot
-readme: https://github.com/scikit-hep/uproot/blob/master/README.rst
+url: https://github.com/scikit-hep/uproot4
+readme: https://github.com/scikit-hep/uproot4/blob/main/README.rst
 docs: https://uproot.readthedocs.io/
 # affiliated: set to true for affiliated packages
 # repo: only if different from url

--- a/_data/projects/manipulation/uproot.yml
+++ b/_data/projects/manipulation/uproot.yml
@@ -1,8 +1,8 @@
 name: uproot
 projlogo: /assets/images/projlogo/logo_uproot.png
-description: Minimalist ROOT I/O in pure Python and Numpy.
+description: ROOT I/O in pure Python and NumPy.
 url: https://github.com/scikit-hep/uproot4
-readme: https://github.com/scikit-hep/uproot4/blob/main/README.rst
+readme: https://github.com/scikit-hep/uproot4/blob/main/README.md
 docs: https://uproot.readthedocs.io/
 # affiliated: set to true for affiliated packages
 # repo: only if different from url


### PR DESCRIPTION
Awkward is still the old one on conda-forge, but I guess it's supposed to be in the same place? CC @JPivarski.
