### PR TITLE
feat: support auto READMEs

### DIFF
--- a/_data/projects/basic/awkward-array.yml
+++ b/_data/projects/basic/awkward-array.yml
@@ -3,7 +3,7 @@ projlogo: /assets/images/projlogo/logo_awkward_array.png
 description: Manipulate JSON-like data with NumPy-like idioms.
 url: https://github.com/scikit-hep/awkward-1.0
 docs: https://awkward-array.org
-docs-title: Website
+docs-title: awkward-array.org
 badges:
   pypi: awkward
   conda-forge: awkward

--- a/_data/projects/basic/awkward-array.yml
+++ b/_data/projects/basic/awkward-array.yml
@@ -3,6 +3,7 @@ projlogo: /assets/images/projlogo/logo_awkward_array.png
 description: Manipulate JSON-like data with NumPy-like idioms.
 url: https://github.com/scikit-hep/awkward-1.0
 docs: https://awkward-array.org
+docs-title: Website
 badges:
   pypi: awkward
   conda-forge: awkward

--- a/_data/projects/basic/awkward-array.yml
+++ b/_data/projects/basic/awkward-array.yml
@@ -2,7 +2,6 @@ name: awkward-array
 projlogo: /assets/images/projlogo/logo_awkward_array.png
 description: Manipulate JSON-like data with NumPy-like idioms.
 url: https://github.com/scikit-hep/awkward-1.0
-readme: https://github.com/scikit-hep/awkward-1.0/blob/main/README.md
 docs: https://awkward-array.org
 badges:
   pypi: awkward

--- a/_data/projects/basic/hepunits.yml
+++ b/_data/projects/basic/hepunits.yml
@@ -1,7 +1,6 @@
 name: hepunits
 description: Units and constants in the HEP system of units.
 url: https://github.com/scikit-hep/hepunits
-readme: https://github.com/scikit-hep/hepunits/blob/master/README.rst
 # docs: <url>
 # affiliated: set to true for affiliated packages
 # repo: only if different from url

--- a/_data/projects/fitting/goofit.yml
+++ b/_data/projects/fitting/goofit.yml
@@ -3,7 +3,6 @@ projlogo: /assets/images/projlogo/logo_goofit.png
 projlogo-style: height:72px;
 description: GPU/OpenMP fitting in Python and C++.
 url: https://github.com/GooFit/GooFit
-readme: https://github.com/GooFit/GooFit/blob/master/README.md
 docs: https://goofit.github.io
 affiliated: true
 # repo: only if different from url

--- a/_data/projects/fitting/iminuit.yml
+++ b/_data/projects/fitting/iminuit.yml
@@ -1,7 +1,6 @@
 name: iminuit
 description: MINUIT from Python - Fitting like a boss.
 url: https://github.com/scikit-hep/iminuit
-readme: https://github.com/scikit-hep/iminuit/blob/master/README.rst
 docs: https://iminuit.readthedocs.io/
 projlogo: /assets/images/projlogo/logo_iminuit.png
 # affiliated: set to true for affiliated packages

--- a/_data/projects/fitting/probfit.yml
+++ b/_data/projects/fitting/probfit.yml
@@ -1,7 +1,6 @@
 name: probfit
 description: Cost function builder. For fitting distributions.
 url: https://github.com/scikit-hep/probfit
-readme: https://github.com/scikit-hep/probfit/blob/master/README.rst
 docs: https://probfit.readthedocs.io/
 # affiliated: set to true for affiliated packages
 deprecated: true

--- a/_data/projects/fitting/zfit.yml
+++ b/_data/projects/fitting/zfit.yml
@@ -1,7 +1,6 @@
 name: zfit
 description: Scalable Pythonic fitting
 url: https://github.com/zfit/zfit
-readme: https://github.com/zfit/zfit/blob/master/README.rst
 docs: https://zfit.readthedocs.io/
 affiliated: true
 # repo: only if different from url

--- a/_data/projects/histogramming/aghast.yml
+++ b/_data/projects/histogramming/aghast.yml
@@ -2,7 +2,6 @@ name: aghast
 projlogo: /assets/images/projlogo/logo_aghast.png
 description: Convert between histogram representations
 url: https://github.com/scikit-hep/aghast
-readme: https://github.com/scikit-hep/aghast/blob/master/README.md
 # docs: https://aghast.readthedocs.io/
 # affiliated: set to true for affiliated packages
 # repo: only if different from url

--- a/_data/projects/histogramming/boost-histogram.yml
+++ b/_data/projects/histogramming/boost-histogram.yml
@@ -3,7 +3,6 @@ projlogo: /assets/images/projlogo/logo_boost_histogram.png
 projlogo-style: height:72px;
 description: Python bindings for the C++14 Boost::Histogram library.
 url: https://github.com/scikit-hep/boost-histogram
-readme: https://github.com/scikit-hep/boost-histogram/blob/develop/README.md
 docs: https://boost-histogram.readthedocs.io/en/latest/
 # affiliated: set to true for affiliated packages
 # repo: only if different from url

--- a/_data/projects/histogramming/hist.yml
+++ b/_data/projects/histogramming/hist.yml
@@ -1,7 +1,6 @@
 name: hist
 description: Hist is a analyst friendly front-end for boost-histogram, designed for Python 3.6+.
 url: https://github.com/scikit-hep/hist
-readme: https://github.com/scikit-hep/hist/blob/develop/README.md
 docs: https://hist.readthedocs.io/en/latest/
 # affiliated: set to true for affiliated packages
 # repo: only if different from url

--- a/_data/projects/histogramming/histbook.yml
+++ b/_data/projects/histogramming/histbook.yml
@@ -2,7 +2,6 @@ name: histbook
 projlogo: /assets/images/projlogo/logo_histbook.png
 description: Versatile, high-performance histogram toolkit for Numpy.
 url: https://github.com/scikit-hep/histbook
-readme: https://github.com/scikit-hep/histbook/blob/master/README.rst
 docs: https://histbook.readthedocs.io/
 deprecated: true
 # affiliated: set to true for affiliated packages

--- a/_data/projects/interface/numpythia.yml
+++ b/_data/projects/interface/numpythia.yml
@@ -1,7 +1,6 @@
 name: numpythia
 description: Interface between Pythia and NumPy.
 url: https://github.com/scikit-hep/numpythia
-readme: https://github.com/scikit-hep/numpythia/blob/master/README.rst
 # docs: <url>
 # affiliated: set to true for affiliated packages
 # repo: only if different from url

--- a/_data/projects/interface/pyhepmc.yml
+++ b/_data/projects/interface/pyhepmc.yml
@@ -1,7 +1,6 @@
 name: pyhepmc
 description: Next generation Python bindings for HepMC3.
 url: https://github.com/scikit-hep/pyhepmc
-readme: https://github.com/scikit-hep/pyhepmc/blob/master/README.md
 # docs: <url>
 # affiliated: set to true for affiliated packages
 # repo: only if different from url

--- a/_data/projects/interface/pyjet.yml
+++ b/_data/projects/interface/pyjet.yml
@@ -1,7 +1,6 @@
 name: pyjet
 description: Interface between FastJet and NumPy.
 url: https://github.com/scikit-hep/pyjet
-readme: https://github.com/scikit-hep/pyjet/blob/master/README.rst
 # docs: <url>
 # affiliated: set to true for affiliated packages
 # repo: only if different from url

--- a/_data/projects/interface/pylhe.yml
+++ b/_data/projects/interface/pylhe.yml
@@ -1,7 +1,6 @@
 name: pylhe
 description: Lightweight Python interface to read Les Houches Event (LHE) files.
 url: https://github.com/scikit-hep/pylhe
-readme: https://github.com/scikit-hep/pylhe/blob/master/README.md
 docs: https://scikit-hep.org/pylhe/
 # affiliated: set to true for affiliated packages
 # repo: only if different from url

--- a/_data/projects/manipulation/formulate.yml
+++ b/_data/projects/manipulation/formulate.yml
@@ -1,7 +1,6 @@
 name: formulate
 description: Easy conversions between different styles of expressions.
 url: https://github.com/scikit-hep/formulate
-readme: https://github.com/scikit-hep/formulate/blob/master/README.rst
 # docs: <url>
 # affiliated: set to true for affiliated packages
 # repo: only if different from url

--- a/_data/projects/manipulation/root-numpy.yml
+++ b/_data/projects/manipulation/root-numpy.yml
@@ -1,7 +1,6 @@
 name: root\_numpy
 description: Interface between ROOT and NumPy.
 url: https://github.com/scikit-hep/root_numpy
-readme: https://github.com/scikit-hep/root_numpy/blob/master/README.rst
 docs: http://scikit-hep.org/root_numpy/
 # affiliated: set to true for affiliated packages
 # repo: only if different from url

--- a/_data/projects/manipulation/root-pandas.yml
+++ b/_data/projects/manipulation/root-pandas.yml
@@ -1,7 +1,6 @@
 name: root\_pandas
 description: Module for conveniently loading/saving ROOT files as pandas DataFrames.
 url: https://github.com/scikit-hep/root_pandas
-readme: https://github.com/scikit-hep/root_pandas/blob/master/README.md
 # docs: <url>
 # affiliated: set to true for affiliated packages
 # repo: only if different from url

--- a/_data/projects/manipulation/uproot-methods.yml
+++ b/_data/projects/manipulation/uproot-methods.yml
@@ -1,7 +1,6 @@
 name: uproot-methods
 description: Pythonic behaviours for non-I/O related ROOT classes.
 url: https://github.com/scikit-hep/uproot-methods
-readme: https://github.com/scikit-hep/uproot-methods/blob/master/README.rst
 # docs: <url>
 # affiliated: set to true for affiliated packages
 # repo: only if different from url

--- a/_data/projects/manipulation/uproot.yml
+++ b/_data/projects/manipulation/uproot.yml
@@ -2,7 +2,6 @@ name: uproot
 projlogo: /assets/images/projlogo/logo_uproot.png
 description: ROOT I/O in pure Python and NumPy.
 url: https://github.com/scikit-hep/uproot4
-readme: https://github.com/scikit-hep/uproot4/blob/main/README.md
 docs: https://uproot.readthedocs.io/
 # affiliated: set to true for affiliated packages
 # repo: only if different from url

--- a/_data/projects/misc/cibuildwheel.yml
+++ b/_data/projects/misc/cibuildwheel.yml
@@ -3,7 +3,6 @@ description: >
   A utility for building all PyPI supported binary wheels on all CI systems.
   [See our guide for instructions](https://scikit-hep.org/developer/gha_wheels).
 url: https://github.com/joerick/cibuildwheel
-readme: https://github.com/joerick/cibuildwheel/blob/master/README.md
 docs: https://cibuildwheel.readthedocs.io
 affiliated: true
 longdescription: |

--- a/_data/projects/misc/conda-forge-root.yml
+++ b/_data/projects/misc/conda-forge-root.yml
@@ -1,7 +1,6 @@
 name: conda-forge ROOT
 description: CERN's ROOT on Conda-Forge.
 url: https://github.com/conda-forge/root-feedstock
-readme: https://github.com/conda-forge/root-feedstock/blob/master/README.md
 image: /assets/images/projlogo/logo_root_conda_forge.png
 projlogo: /assets/images/projlogo/logo_root_conda_forge.png
 projlogo-style: height:72px;

--- a/_data/projects/misc/scikit-hep-testdata.yml
+++ b/_data/projects/misc/scikit-hep-testdata.yml
@@ -1,7 +1,6 @@
 name: scikit-hep-testdata
 description: Common package to provide example files (e.g., ROOT) for testing and developing packages against.
 url: https://github.com/scikit-hep/scikit-hep-testdata
-readme: https://github.com/scikit-hep/scikit-hep-testdata/blob/master/README.md
 # docs: <url>
 # affiliated: set to true for affiliated packages
 # repo: only if different from url

--- a/_data/projects/misc/scikit-hep.yml
+++ b/_data/projects/misc/scikit-hep.yml
@@ -1,7 +1,6 @@
 name: scikit-hep
 description: Toolset of interfaces and tools for Particle Physics. To become a metapackage.
 url: https://github.com/scikit-hep/scikit-hep
-readme: https://github.com/scikit-hep/scikit-hep/blob/master/README.rst
 # docs: <url>
 # affiliated: set to true for affiliated packages
 # repo: only if different from url

--- a/_data/projects/ml/NNDrone.yml
+++ b/_data/projects/ml/NNDrone.yml
@@ -1,7 +1,6 @@
 name: NNDrone
 description: Collection of tools and algorithms to enable conversion of HEP ML to mass usage model.
 url: https://github.com/scikit-hep/NNDrone
-readme: https://github.com/scikit-hep/NNDrone/blob/master/README.md
 # docs: <url>
 # affiliated: set to true for affiliated packages
 # repo: only if different from url

--- a/_data/projects/particle/decaylanguage.yml
+++ b/_data/projects/particle/decaylanguage.yml
@@ -2,7 +2,6 @@ name: DecayLanguage
 projlogo: /assets/images/projlogo/logo_decaylanguage.png
 description: Describe and convert particle decays between digital representations.
 url: https://github.com/scikit-hep/decaylanguage
-readme: https://github.com/scikit-hep/decaylanguage/blob/master/README.md
 docs: https://decaylanguage.readthedocs.io/
 # affiliated: set to true for affiliated packages
 # repo: only if different from url

--- a/_data/projects/particle/particle.yml
+++ b/_data/projects/particle/particle.yml
@@ -2,7 +2,6 @@ name: Particle
 projlogo: /assets/images/projlogo/logo_particle.png
 description: PDG particle data and identification codes.
 url: https://github.com/scikit-hep/particle
-readme: https://github.com/scikit-hep/particle/blob/master/README.rst
 # docs: <url>
 # affiliated: set to true for affiliated packages
 # repo: only if different from url

--- a/_data/projects/statistics/hepstats.yml
+++ b/_data/projects/statistics/hepstats.yml
@@ -3,7 +3,6 @@ projlogo: /assets/images/projlogo/logo_hepstats.png
 projlogo-style: height:65px;
 description: Statistics tools and utilities.
 url: https://github.com/scikit-hep/hepstats
-readme: https://github.com/scikit-hep/hepstats/blob/master/README.md
 docs: https://scikit-hep.org/hepstats/
 # affiliated: set to true for affiliated packages
 # repo: only if different from url

--- a/_data/projects/statistics/pyhf.yml
+++ b/_data/projects/statistics/pyhf.yml
@@ -3,7 +3,6 @@ projlogo: /assets/images/projlogo/logo_pyhf.png
 projlogo-style: height:96px;
 description: pure-Python implementation of HistFactory models.
 url: https://github.com/scikit-hep/pyhf
-readme: https://github.com/scikit-hep/pyhf/blob/master/README.rst
 docs: https://scikit-hep.org/pyhf/
 # affiliated: set to true for affiliated packages
 # repo: only if different from url

--- a/_data/projects/visualization/mplhep.yml
+++ b/_data/projects/visualization/mplhep.yml
@@ -3,7 +3,6 @@ projlogo: /assets/images/projlogo/logo_mplhep.png
 projlogo-style: height:72px;
 description: Plotting and styling helpers for matplotlib.
 url: https://github.com/scikit-hep/mplhep
-readme: https://github.com/scikit-hep/mplhep/blob/master/README.md
 docs: https://mplhep.readthedocs.io/
 # affiliated: set to true for affiliated packages
 # repo: only if different from url

--- a/_data/projects/visualization/vegascope.yml
+++ b/_data/projects/visualization/vegascope.yml
@@ -1,7 +1,6 @@
 name: vegascope
 description: View Vega/Vega-Lite plots in your web browser from local or remote Python processes.
 url: https://github.com/scikit-hep/vegascope
-readme: https://github.com/scikit-hep/vegascope/blob/master/README.rst
 # docs: <url>
 # affiliated: set to true for affiliated packages
 # repo: only if different from url

--- a/pages/packages/documentation.md
+++ b/pages/packages/documentation.md
@@ -27,7 +27,7 @@ READMEs still contain handy \"getting started\" sections.
 |---------|--------|---------------|
 {% for project in items %}
 {%- if project.docs  -%}
-{%- capture docs -%} [Read the Docs]({{project.docs}}) {%- endcapture -%}
+{%- capture docs -%} [{{project.docs-title | default: "Read the Docs"}}]({{project.docs}}) {%- endcapture -%}
 {%- else -%}
 {%- assign docs="" -%}
 {%- endif -%}

--- a/pages/packages/documentation.md
+++ b/pages/packages/documentation.md
@@ -31,5 +31,11 @@ READMEs still contain handy \"getting started\" sections.
 {%- else -%}
 {%- assign docs="" -%}
 {%- endif -%}
-| [{{project.name}}]({{project.url}}) | [README]({{project.readme}}) | {{docs}} |
+| [{{project.name}}]({{project.url}}) | [README](
+{%- if project.readme -%}
+{{project.readme}}
+{%- else -%}
+{{project.url}}/#readme
+{%- endif -%}
+) | {{docs}} |
 {% endfor %}


### PR DESCRIPTION
Closes #100.

CC @jpivarski, it is based on his idea.

- docs: use main page `/#readme` as README unless a custom readme is specified.
- docs: allow docs title override (Awkward's docs isn't really a ReadTheDocs, but a Website)
