### PR TITLE
chore: updating cibw

### DIFF
--- a/pages/developers/gha_pure.md
+++ b/pages/developers/gha_pure.md
@@ -70,20 +70,15 @@ with the name "CI/CD", you can just combine the two `on` dicts.
     steps:
     - uses: actions/checkout@v1
 
-    - uses: actions/setup-python@v2
-
-    - name: Install wheel and SDist requirements
-      run: python -m pip install "build" "twine"
-
     - name: Build SDist and wheel
-      run: python -m build
+      run: pipx run --spec build pyproject-build
 
     - uses: actions/upload-artifact@v2
       with:
         path: dist/*
 
     - name: Check metadata
-      run: twine check dist/*
+      run: pipx run twine check dist/*
 
 ```
 {% endraw %}
@@ -96,6 +91,15 @@ By default this will make an SDist and a wheel from the package in the current
 directory, and they will be placed in `./dist`. You can only build SDist
 (`-s`), only build wheel (`-w`), change the output folder (`-o <dir>`) or give
 a different input folder if you want.
+
+You could use the setup-python action, install `build` and `twine` with `pip`,
+and then use `python -m build` or `pyproject-build`, but it's better to use
+`pipx` to install and run python applications. Pipx is provided by default by
+Github Actions (in fact, they use it to setup other applications).
+
+Also, we currently have to use `pipx run --spec build pyproject-build` because
+the module name (`build`) and the program `pyproject-build` do not match. A
+future update to pipx and build may fix this so `pipx run build` will be enough.
 
 <details><summary>Breaking up or classic SDist buils (Click to expand)</summary>
 
@@ -183,16 +187,11 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
-    - uses: actions/setup-python@v2
-
-    - name: Install wheel and SDist requirements
-      run: python -m pip install "build" "twine"
-
-    - name: Build SDist & wheel
-      run: python -m build
+    - name: Build wheel and SDist
+      run: pipx run --spec build pyproject-build
 
     - name: Check metadata
-      run: twine check dist/*
+      run: pipx run twine check dist/*
 
     - uses: actions/upload-artifact@v2
       with:

--- a/pages/developers/style.md
+++ b/pages/developers/style.md
@@ -26,7 +26,7 @@ Here is a minimal `.pre-commit-config.yaml` file with some handy options:
 ```yaml
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.3.0
+  rev: v3.4.0
   hooks:
   - id: check-added-large-files
   - id: check-case-conflict
@@ -95,7 +95,7 @@ Here is the snippet to add Black to your `.pre-commit-config.yml`:
 
 ```yaml
 - repo: https://github.com/psf/black
-  rev: 20.08b1
+  rev: 20.8b1
   hooks:
   - id: black
 ```
@@ -206,7 +206,7 @@ The MyPy addition for pre-commit:
 You can also add items to the virtual environment setup for mypy by pre-commit, for example:
 
 ```yaml
-    additional_dependencies: [attrs==19.3.0]
+    additional_dependencies: [attrs==20.3.0]
 ```
 
 MyPy has a config section in `setup.cfg` that looks like this:

--- a/pages/developers/style.md
+++ b/pages/developers/style.md
@@ -197,7 +197,7 @@ The MyPy addition for pre-commit:
 
 ```yaml
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.790
+  rev: v0.800
   hooks:
   - id: mypy
     files: src

--- a/pages/developers/style.md
+++ b/pages/developers/style.md
@@ -215,7 +215,6 @@ MyPy has a config section in `setup.cfg` that looks like this:
 ```ini
 [mypy]
 files = src
-pretty = True
 python_version = 3.6
 warn_unused_configs = True
 warn_unused_ignores = True
@@ -230,9 +229,9 @@ checks as you go. You can ignore missing imports on libraries as shown above,
 on section each. And you can disable MyPy on a line with `# type: ignore`. Once
 you are ready to start checking more, you can look at adding
 `check_untyped_defs`, `disallow_untyped_defs`, `disallow_incomplete_defs`, and
-more, up until `strict`. You can add these *per file* by adding a `# mypy:
-strict` (or any other less stringent check) at the top of the file. MyPy does
-not support pyproject.toml configuration yet.
+more. You can add these *per file* by adding a `# mypy: <option>` the top of
+the file. MyPy does not support pyproject.toml configuration yet. You can also
+pass `--strict` on the command line.
 
 
 ## Flake8


### PR DESCRIPTION
Updating cibuildwheel to 1.8.0, which includes Arch emulation! Also using pipx to run build and twine, since it's installed by default on the GHA runners and it's the right tool to use for applications (pip is for importable libraries). Also fixes a typo with the black version, and bumps a few things. MyPy 0.800 is out, but the pre-commit mirror hasn't updated yet.