### PR TITLE
chore: Note root_numpy and root-pandas are deprecated

### DIFF
--- a/_data/projects/manipulation/root-numpy.yml
+++ b/_data/projects/manipulation/root-numpy.yml
@@ -3,6 +3,7 @@ description: Interface between ROOT and NumPy.
 url: https://github.com/scikit-hep/root_numpy
 docs: http://scikit-hep.org/root_numpy/
 # affiliated: set to true for affiliated packages
+deprecated: true
 # repo: only if different from url
 badges:
   pypi: root-numpy

--- a/_data/projects/manipulation/root-pandas.yml
+++ b/_data/projects/manipulation/root-pandas.yml
@@ -3,6 +3,7 @@ description: Module for conveniently loading/saving ROOT files as pandas DataFra
 url: https://github.com/scikit-hep/root_pandas
 # docs: <url>
 # affiliated: set to true for affiliated packages
+deprecated: true
 # repo: only if different from url
 badges:
   pypi: root-pandas


### PR DESCRIPTION
Given [the discussion on Gitter](https://gitter.im/Scikit-HEP/community?at=60550684f07ffa1eb551d253) mark `root_numpy` and `root-pandas` as deprecated.