### PR TITLE
chore: use newer pipx run syntax

### DIFF
--- a/pages/developers/gha_pure.md
+++ b/pages/developers/gha_pure.md
@@ -70,7 +70,7 @@ with the name "CI/CD", you can just combine the two `on` dicts.
     - uses: actions/checkout@v1
 
     - name: Build SDist and wheel
-      run: pipx run --spec build pyproject-build
+      run: pipx run build
 
     - uses: actions/upload-artifact@v2
       with:
@@ -95,10 +95,6 @@ You could use the setup-python action, install `build` and `twine` with `pip`,
 and then use `python -m build` or `pyproject-build`, but it's better to use
 `pipx` to install and run python applications. Pipx is provided by default by
 Github Actions (in fact, they use it to setup other applications).
-
-Also, we currently have to use `pipx run --spec build pyproject-build` because
-the module name (`build`) and the program `pyproject-build` do not match. A
-future update to pipx and build may fix this so `pipx run build` will be enough.
 
 <details><summary>Classic SDist builds (click to expand)</summary>
 
@@ -187,7 +183,7 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Build wheel and SDist
-      run: pipx run --spec build pyproject-build
+      run: pipx run build
 
     - name: Check metadata
       run: pipx run twine check dist/*

--- a/pages/developers/gha_wheels.md
+++ b/pages/developers/gha_wheels.md
@@ -80,7 +80,7 @@ before, will work:
         submodules: true  # Optional if you have submodules
 
     - name: Build SDist
-      run: pipx run --spec build pyproject-build --sdist
+      run: pipx run build --sdist
 
     - uses: actions/upload-artifact@v2
       with:
@@ -89,7 +89,7 @@ before, will work:
 
 Using `checkout@v1` here is easier than `v2` if you use `setuptools_scm`, at
 least for now. You can instead install build via pip and use `python -m build
---sdist`. You can also pin the version with `pipx run --spec build==...`.
+--sdist`. You can also pin the version with `pipx run build==...`.
 
 ## The core job (3 main OS's)
 


### PR DESCRIPTION
This was implemented in pipxproject/pipx#615 and pypa/build#247, and the GitHub Actions runners have been updated to the latest pipx, so this now works with the simpler syntax. Matching Cookie PR: scikit-hep/cookie#11
