### PR TITLE
fix: Revise prune strategy for MANIFEST.in to properly remove all

### DIFF
--- a/pages/developers/packaging.md
+++ b/pages/developers/packaging.md
@@ -403,7 +403,7 @@ complete control over a src structure, though be sure to update it to include
 any files that need to be included:
 
 ```
-prune *
+prune **
 graft src
 graft tests
 


### PR DESCRIPTION
Resolves #130 

`prune *` does not fully remove _all_ files, but `prune **` will.

For reference, c.f. https://github.com/scikit-hep/pyhf/pull/1449