### PR TITLE
fix: remove deprecated projects from the main page

### DIFF
--- a/_includes/package_table.html
+++ b/_includes/package_table.html
@@ -4,6 +4,14 @@
   <h3 id="{{cat.name}}">{{cat.title}}:</h3>
   {% for item in listing -%}
     {%- assign project = item[1] -%}
+    {% if include.deprecated %}
+      {%- assign include_not_deprecated = false -%}
+    {% else %}
+      {%- assign include_not_deprecated = true -%}
+    {% endif %}
+    {%- if include_not_deprecated and project.deprecated -%}
+      {%- continue -%}
+    {%- endif -%}
     {%- assign classes = "project" -%}
     {%- if project.affiliated -%}
       {%- assign classes = classes | append: " affiliated" -%}

--- a/index.md
+++ b/index.md
@@ -13,15 +13,17 @@ The Scikit-HEP project is a community-driven and community-oriented project
 with the aim of providing Particle Physics at large with an ecosystem for data
 analysis in Python. [Read more →]({{site.baseurl}}{% link pages/about/index.md %} )
 
-See our [developer pages]({{site.baseurl}}{% link pages/developers/index.md %}) for information on developing Python packages!
+See our [developer pages]({{site.baseurl}}{% link pages/developers/index.md %})
+for information on developing Python packages!
 
 {% include package_table.html %}
 
 In some cases, the packages provide a bridge between different
 technologies and/or popular packages from the Python scientific software
-stack.
+stack. If you are looking for a deprecated package, see the [full package list][].
 
 [github-badge]: https://img.shields.io/badge/GitHub--blue?style=social&logo=GitHub
 [GitHub repository]: https://github.com/scikit-hep/
 [gitter-skhep-link]:   https://gitter.im/Scikit-HEP/community
 [gitter-skhep-badge]:  https://badges.gitter.im/Scikit-HEP/community.svg
+[full package list]: {{site.baseurl}}{% link pages/packages/index.md %}

--- a/pages/packages/index.md
+++ b/pages/packages/index.md
@@ -9,4 +9,4 @@ has_children: true
 Projects {#projects}
 ========
 
-{% include package_table.html badges="True" %}
+{% include package_table.html badges="True" deprecated="True" %}


### PR DESCRIPTION
This makes the front page cleaner, avoiding showing a bunch of deprecated red items on first visit.
