### PR TITLE
chore: use pre-commit/mirrors-clang-format instead

### DIFF
--- a/pages/developers/style.md
+++ b/pages/developers/style.md
@@ -498,7 +498,7 @@ If you have C++ code, you should have a `.clang-format` file and use the
 following pre-commit config:
 
 ```yaml
-- repo: https://github.com/ssciwr/clang-format-hook
+- repo: https://github.com/pre-commit/mirrors-clang-format
   rev: v13.0.0
   hooks:
   - id: clang-format


### PR DESCRIPTION
The original repository is being deprecated in favor of the automatically maintained https://github.com/pre-commit/mirrors-clang-format. See https://github.com/ssciwr/clang-format-hook. Also https://github.com/scikit-hep/cookie/pull/44.