### PR TITLE
Revert "feat: add pycln as a recommendation"

### DIFF
--- a/pages/developers/style.md
+++ b/pages/developers/style.md
@@ -251,27 +251,6 @@ command line. `strict = true` is now allowed in config files, too.
 
 [mypy page]: {{ site.baseurl }}{% link pages/developers/mypy.md %}
 
-## PyCln
-
-[PyCln][] will clean up your imports if you have any that are not needed. There is
-a Flake8 check for this, but it's usually nicer to automatically do the cleanup
-instead of forcing a user to manually delete unneeded imports.
-
-```yaml
-- repo: https://github.com/hadialqattan/pycln
-  rev: v1.0.3
-  hooks:
-  - id: pycln
-    args: [--config=pyproject.toml]
-```
-
-You can configure it in the `[tool.pycln]` section of your `pyproject.toml`:
-
-```toml
-[tool.pycln]
-all = true
-```
-
 ## Flake8
 
 [Flake8][] can check a collection of good practices for you, ranging from
@@ -513,4 +492,3 @@ If you have shell scripts, you can protect against common mistakes using [shellc
 ```
 
 [Flake8]: https://gitlab.com/pycqa/flake8
-[PyCln]: https://hadialqattan.github.io/pycln


### PR DESCRIPTION
Reverts scikit-hep/scikit-hep.github.io#154, removes pycln as a recommendation, due to hadialqattan/pycln#81. I'm sorry for the issue; I usually check dependencies and adding an upper cap is a [huge red flag](https://twitter.com/HenrySchreiner3/status/1454080177785475080) for me, especially on Python version, but I never checked this one.