### PR TITLE
chore: use Python 3.7+ for examples

### DIFF
--- a/_data/projects/misc/conda-forge-root.yml
+++ b/_data/projects/misc/conda-forge-root.yml
@@ -18,8 +18,8 @@ longdescription: |
     which is a popular choice for Scikit-HEP users, the official ROOT team
     recommendation for building it on top of the Conda stack was: too hard,
     don't do it.  But now, the ROOT [Conda-Forge][] package provides a fully
-    featured ROOT binary package for macOS or Linux, Python 2.7 and 3.6--3.8,
-    fully integrated into the Conda environment system!
+    featured ROOT binary package for macOS or Linux, fully integrated into the
+    Conda environment system!
 
     The Conda-Forge ROOT project has been developed by Scikit-HEP admins and is
     used in the Continuous Integration (CI) system of several of our packages

--- a/pages/developers/gha_basic.md
+++ b/pages/developers/gha_basic.md
@@ -82,7 +82,7 @@ OS's if you'd like by adding them to the matrix and inputting them into
       fail-fast: false
       matrix:
         python-version:
-        - "3.6"
+        - "3.7"
         - "3.10"
     name: Check Python ${{ matrix.python-version }}
     steps:

--- a/pages/developers/nox.md
+++ b/pages/developers/nox.md
@@ -119,7 +119,7 @@ You can parametrize sessions. either on Python or on any other item.
 
 ```python
 # Shortcut to parametrize Python
-@nox.session(python=["3.6", "3.7"])
+@nox.session(python=["3.7", "3.8", "3.9", "3.10"])
 def my_session(session: nox.Session) -> None: ...
 
 # General parametrization

--- a/pages/developers/packaging.md
+++ b/pages/developers/packaging.md
@@ -259,7 +259,6 @@ classifiers =
     Programming Language :: C++
     Programming Language :: Python
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -281,7 +280,7 @@ project_urls =
 packages = find:
 install_requires =
     numpy>=1.13.3
-python_requires = >=3.6
+python_requires = >=3.7
 include_package_data = True
 package_dir =
     =src

--- a/pages/developers/pep621.md
+++ b/pages/developers/pep621.md
@@ -59,7 +59,7 @@ maintainers = [
   {name="Scikit-HEP", email="scikit-hep-admins@googlegroups.com"},
 ]
 license = {file="LICENSE"}
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 
 dependencies = [
   "numpy>=1.13.3",
@@ -69,7 +69,6 @@ classifiers = [
   "Development Status :: 4 - Beta",
   "License :: OSI Approved :: BSD License",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.6",
   "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",

--- a/pages/developers/style.md
+++ b/pages/developers/style.md
@@ -209,23 +209,9 @@ MyPy has a config section in `pyproject.toml` that looks like this:
 ```ini
 [tool.mypy]
 files = "src"
-python_version = "3.6"
+python_version = "3.7"
 warn_unused_configs = true
-
-# Currently (0.812) identical to --strict
-disallow_any_generics = true
-disallow_subclassing_any = true
-disallow_untyped_calls = true
-disallow_untyped_defs = true
-disallow_incomplete_defs = true
-check_untyped_defs = true
-disallow_untyped_decorators = true
-no_implicit_optional = true
-warn_redundant_casts = true
-warn_unused_ignores = true
-warn_return_any = true
-no_implicit_reexport = true
-strict_equality = true
+strict = true
 
 # You can disable imports or control per-module/file settings here
 [[tool.mypy.overrides]]

--- a/pages/supported-python-versions.md
+++ b/pages/supported-python-versions.md
@@ -32,7 +32,7 @@ developers have adopted the following guidelines for the Scikit-HEP packages.
       this adds a `py2` identifier to the name and can confuse users and pip.
 * Foundational packages in Scikit-HEP _may_ chose to match Python EOL instead of NEP
   29. A key feature of [NEP 29][] is that it targets mature, slowly developing libraries.
-  If a user is on Python 3.6, they get an older version of NumPy, but that is
+  If a user is on Python 3.6 or 3.7, they get an older version of NumPy, but that is
   likely sufficient.
 * It is not recommended for any package in Scikit-HEP to support older versions
   of Python than EOL versions (Python 3.5 or less).
@@ -74,17 +74,17 @@ software too.
 Statement on Python 3.6
 -----------------------
 
-This was a very popular version of Python, and is the "default" version of Python
-on CentOS 7, Ubuntu 18.04, and even CentOS 8 (though not well supported, you should
-use streams there). However, it will hit EOL at the end of 2021, [NEP 29][] has
-already dropped it, and it really limits use of static typing
-(`from __future__ import annotations`, `__class_getitem__`, and more). Many
-"foundational" Scikit-HEP libraries have not yet dropped 3.6 support since we are
-in more active development than the libraries that prompted NEP 29, but some
-packages already are dropping support and more will follow. Users should make an
-effort to always use at least Python 3.7 in analysis, and preferably the highest
-version possible. Note that due to usage of "internal" bytecode, Numba can take up
-to 5 months to update after a Python release.
+This was a very popular version of Python, and is the "default" version of
+Python on CentOS 7, Ubuntu 18.04, and even CentOS 8 (though not well supported,
+you should use streams there). However, it is at EOL, [NEP 29][] has already
+dropped it, and it really limits use of static typing (`from __future__ import
+annotations`, `__class_getitem__`, and more). Many "foundational" Scikit-HEP
+libraries have not yet dropped 3.6 support since we are in more active
+development than the libraries that prompted NEP 29, but some packages already
+are dropping support and more will follow. Users should make an effort to always
+use at least Python 3.7 in analysis, and preferably the highest version
+possible. Note that due to usage of "internal" bytecode, Numba can take up to 5
+months to update after a Python release.
 
 
 [NEP 29]: https://numpy.org/neps/nep-0029-deprecation_policy.html


### PR DESCRIPTION
Python 3.6 hit EOL today! New users should at least be on 3.7, so let's update the examples.

Also updated the cookie https://github.com/scikit-hep/cookie/pull/63