### PR TITLE
chore: improve and run bump script, new Black

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -27,7 +27,7 @@ def bump(session: nox.Session) -> None:
 
     for proj, old_version in old_versions.items():
         new_version = session.run("lastversion", proj, silent=True).strip()
-        
+
         if old_version.lstrip("v") == new_version:
             continue
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -25,23 +25,19 @@ def bump(session: nox.Session) -> None:
     txt = style.read_text()
     old_versions = {m[1]: m[2].strip('"') for m in VERS.finditer(txt)}
 
-    new_versions = {
-        proj: session.run("lastversion", proj, "--pre", silent=True).strip()
-        for proj in old_versions
-    }
+    for proj, old_version in old_versions.items():
+        new_version = session.run("lastversion", proj, silent=True).strip()
+        
+        if old_version.lstrip("v") == new_version:
+            continue
 
-    changed_versions = {
-        proj: new_versions[proj]
-        for proj in old_versions
-        if old_versions[proj].lstrip("v") != new_versions[proj]
-    }
+        if old_version.startswith("v"):
+            new_version = f"v{new_version}"
 
-    for proj, vers in changed_versions.items():
-        if old_versions[proj].startswith("v"):
-            vers = f"v{vers}"
-        before = REPL_LINE.format(proj, old_versions[proj])
-        after = REPL_LINE.format(proj, vers)
-        session.log(f"Bump: {old_versions[proj]} -> {vers}")
+        before = REPL_LINE.format(proj, old_version)
+        after = REPL_LINE.format(proj, new_version)
+
+        session.log(f"Bump: {old_version} -> {new_version}")
         txt = txt.replace(before, after)
 
     style.write_text(txt)

--- a/pages/developers/style.md
+++ b/pages/developers/style.md
@@ -89,7 +89,7 @@ Here is the snippet to add Black to your `.pre-commit-config.yml`:
 
 ```yaml
 - repo: https://github.com/psf/black
-  rev: "21.12b0"
+  rev: "22.1.0"
   hooks:
   - id: black
 ```
@@ -205,7 +205,7 @@ The MyPy addition for pre-commit:
 
 ```yaml
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: "v0.930"
+  rev: "v0.931"
   hooks:
   - id: mypy
     files: src


### PR DESCRIPTION
I finally can remove the `--pre` to `lastversion` due to a non-beta Black release!

Also reworked the update script a bit to get the version check and version bump messages closer together.