### PR TITLE
feat: add tabs for other PEP 621 backends

### DIFF
--- a/pages/developers/nox.md
+++ b/pages/developers/nox.md
@@ -65,7 +65,9 @@ On GitHub Actions or Azure, pipx is available by default, so you should use
 
 You can now access all versions of Python from nox. At least in GitHub Actions,
 you should add `--forcecolor` to your nox runs to get color output in your
-logs.
+logs, or set `env: FORCE_COLOR: 3`. You should also always add
+`--error-on-missing-interpreters` in CI, because nox considers a missing
+interpreter to be "passing".
 
 ### Introduction
 

--- a/pages/developers/pep621.md
+++ b/pages/developers/pep621.md
@@ -14,8 +14,9 @@ you select doesn't really matter that much; they all use a standard
 configuration language specified in [PEP 621][]. The PyPA's Flit is a great
 option.  In the future, scikit-build and meson may support this sort of
 configuration, enabling binary extension packages to benefit too. These [PEP
-621][] tools currently include [Flit][], [PDM][], [Trampolim][], and [Whey][].
-[Setuptools][] might gain support in 2022, and [Poetry][] might as well.
+621][] tools currently include [Flit][], [Hatch][], [PDM][], [Trampolim][], and
+[Whey][].  [Setuptools][] has experimental support, and [Poetry][] might as
+well.
 
 > #### Classic files
 >
@@ -37,11 +38,41 @@ configuration, enabling binary extension packages to benefit too. These [PEP
 Packages must have a `pyproject.toml` file that selects the backend (this one
 is for Flit):
 
+<div class="skhep-bar d-flex m-2" style="justify-content:center;">
+  <button class="skhep-bar-item btn m-2 btn-purple" onclick="openTab('flit')" id='flit-btn'>Flit</button>
+  <button class="skhep-bar-item btn m-2" onclick="openTab('hatch')" id='hatch-btn'>Hatch</button>
+  <button class="skhep-bar-item btn m-2" onclick="openTab('pdm')" id='pdm-btn'>PDM</button>
+  <button class="skhep-bar-item btn m-2" onclick="openTab('setuptools')" id='setuptools-btn'>Setuptools (experimental)</button>
+</div>
+
+<div class="skhep-tab" markdown="1" id="flit">
 ```toml
 [build-system]
 requires = ["flit_core >=3.2"]
 build-backend = "flit_core.buildapi"
 ```
+</div>
+<div class="skhep-tab" markdown="1" id="hatch" style="display:none;">
+```toml
+[build-system]
+requires = ["hatchling >=0.7"]
+build-backend = "hatchling.build"
+```
+</div>
+<div class="skhep-tab" markdown="1" id="pdm" style="display:none;">
+```toml
+[build-system]
+requires = ["pdm-pep517"]
+build-backend = "pdm.pep517.api"
+```
+</div>
+<div class="skhep-tab" markdown="1" id="setuptools" style="display:none;">
+```toml
+[build-system]
+requires = ["setuptools @ git+https://github.com/pypa/setuptools@experimental/support-pyproject"]
+build-backend = "setuptools.build_meta"
+```
+</div>
 
 ## pyproject.toml: project
 
@@ -77,7 +108,7 @@ classifiers = [
 ]
 
 [project.urls]
-Source = "https://github.com/scikit-hep/package"
+Homepage = "https://github.com/scikit-hep/package"
 Documentation = "https://package.readthedocs.io/"
 "Bug Tracker" = "https://github.com/scikit-hep/package/issues"
 Discussions = "https://github.com/scikit-hep/package/discussions"
@@ -85,8 +116,9 @@ Changelog = "https://package.readthedocs.io/en/latest/changelog.html"
 ```
 
 You can read more about each field, and all allowed fields, in [PEP 621][],
-[Flit](https://flit.readthedocs.io/en/latest/pyproject_toml.html#new-style-metadata) or
-[Whey](https://whey.readthedocs.io/en/latest/configuration.html).
+[Flit](https://flit.readthedocs.io/en/latest/pyproject_toml.html#new-style-metadata)
+or [Whey](https://whey.readthedocs.io/en/latest/configuration.html). Note that
+"Homepage" is special, and replaces the old url setting.
 
 ## Package structure
 
@@ -99,8 +131,9 @@ instead of the installed version - this obviously tends to break if you build
 parts of the library or if you access package metadata.
 
 This sadly is not part of the standard metadata in `[project]`, so it depends
-on what backend you you use. Flit and PDM use automatic detection, while
-Trampolim and whey do not, requiring a `tool` setting.
+on what backend you you use. Flit, Hatch, PDM, and (experimental) setuptools
+use automatic detection, while Trampolim and whey do not, requiring a `tool`
+setting.
 
 
 ## Versioning
@@ -146,5 +179,22 @@ providing at least `test`, `docs`, and `dev`.
 [pdm]: https://pdm.fming.dev
 [trampolim]: https://github.com/FFY00/trampolim
 [whey]: https://whey.readthedocs.io
+[hatch]: https://ofek.dev/hatch/latest/
 [setuptools]: https://setuptools.readthedocs.io
 [pep 621]: https://www.python.org/dev/peps/pep-0621
+
+<script>
+function openTab(tabName) {
+  var tab = document.getElementsByClassName("skhep-tab");
+  for (const t of tab) {
+    t.style.display = t.id == tabName ? "block" : "none";
+  }
+  var btn = document.getElementsByClassName("skhep-bar-item");
+  for (const b of btn) {
+    if(b.id == tabName.concat("-btn"))
+      b.classList.add("btn-purple");
+    else
+      b.classList.remove("btn-purple");
+  }
+}
+</script>


### PR DESCRIPTION
Probably should add tabs here if I'm trying to get it into packaging.python.org in https://github.com/pypa/packaging.python.org/pull/1031 . :)

- chore: mention color workaround
- feat: include multiple backends
