### PR TITLE
Add Miniforge instructions for users

### DIFF
--- a/pages/installing-packages.md
+++ b/pages/installing-packages.md
@@ -9,7 +9,7 @@ nav_order: 35
 
 Many ways to install Python and Python packages have been developed over the years, and not all of them are compatible. We support both major systems: PyPI with virtual environments and conda-forge. For a newcomer, conda-forge is usually the simplest way to start an analysis, so this page covers the best way to set up a working conda-forge environment.
 
-If you're having trouble installing Scikit-HEP packages (e.g. `pip install` fails with an error or you get an `ImportError`/`ModuleNotFoundError`), try following the instructions below to set up a conda-forge environment using `mamba`
+If you're having trouble installing Scikit-HEP packages (e.g. `pip install` fails with an error or you get an `ImportError`/`ModuleNotFoundError`), try following the instructions below to set up a conda-forge environment using `mamba`.
 
 ![A mess of Python environments](https://imgs.xkcd.com/comics/python_environment.png)
 
@@ -29,15 +29,15 @@ You likely have a package manager for your operating system, such as Homebrew, a
 
 # What is "mamba"?
 
-We recommend using "mamba", which is a drop-in replacement for "conda" that is many times faster. You particularly notice it when a package has many dependencies or complex version constraints on its dependencies.
+We recommend using `mamba`, which is a drop-in replacement for `conda` that is many times faster. You particularly notice it when a package has many dependencies or complex version constraints on its dependencies.
 
-In fact, the conda developers are [incorporating mamba into conda](https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community), though at the time of this writing, that integration is still experimental. These instructions will describe how to use mamba directly.
+In fact, the conda developers are [incorporating mamba into conda](https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community), though at the time of this writing, that integration is still experimental. These instructions will describe how to use `mamba` directly.
 
 # Where will the files go?
 
 The entire Python distribution, with all packages and the shared libraries that support them, will go in a new directory, most likely in your home directory and named `mambaforge`. All of the files in it are installed with your own user permissions (i.e. not superuser/`sudo`).
 
-<details markdown="1"><summary> How to get rid of them if you change your mind (click here)</summary>
+<details markdown="1"><summary>How to get rid of them if you change your mind (click here)</summary>
 
 1. Delete that directory with `rm -rf ~/mambaforge`.
 2. Delete a file named `~/.condarc`, if you have one.
@@ -47,7 +47,7 @@ Those three steps will remove any vestige of the conda installation.
 
 </details>
 
-## How to save an old package list before deleting it
+<details markdown="1"><summary>How to save an old package list before deleting it (click here)</summary>
 
 If you already have a conda installation, you can bundle your current environment into an environment file with
 
@@ -61,13 +61,15 @@ After reinstalling, you can reconstruct it with
 conda env create -f old-environment.yml
 ```
 
+</details>
+
 # Installing Miniforge
 
 Miniforge is [distributed on GitHub](https://github.com/conda-forge/miniforge).
 
 The steps of the installation procedure are (1) download an installer script, (2) run it, and (3) answer interactive prompts.
 
-Of the four combinations Miniforge gives you (conda vs mamba, Python vs PyPy), [we recommend mamba with Python, which is this table](https://github.com/conda-forge/miniforge#mambaforge).
+Of the four combinations Miniforge gives you (`conda` vs `mamba`, Python vs PyPy), [we recommend mamba with Python, which is this table](https://github.com/conda-forge/miniforge#mambaforge).
 
 Within each table is a list of architectures. On Mac and Linux, you can get the name of your architecture from
 
@@ -89,7 +91,7 @@ The interactive prompts will ask you where you want to install it (default is `~
 
 ## Using Miniforge
 
-Now you're ready to go. Instructions online tell you how to install packages, like `conda install package-name`. Since you installed "mamba", you can replace `conda install` with `mamba install` to make the dependency resolution much faster. There are no other differences, and you can always fall back on using the `conda` command.
+Now you're ready to go. Instructions online tell you how to install packages, like `conda install package-name`. Since you installed `mamba`, you can replace `conda install` with `mamba install` to make the dependency resolution much faster. There are no other differences, and you can always fall back on using the `conda` command.
 
 One of the first commands you'll probably want to do is
 

--- a/pages/installing-packages.md
+++ b/pages/installing-packages.md
@@ -1,0 +1,110 @@
+---
+layout: page
+title: Installing Python packages with conda-forge
+permalink: /installing-packages
+nav_order: 35
+---
+
+# Avoiding the spaghetti installation
+
+Many ways to install Python and Python packages have been developed over the years, and not all of them are compatible.
+
+If you're having trouble installing Scikit-HEP packages (e.g. `pip install` fails with an error or you get an `ImportError`/`ModuleNotFoundError`), try following the instructions below to set up a conda-forge environment.
+
+![A mess of Python environments](https://imgs.xkcd.com/comics/python_environment.png)
+
+The instructions are at the bottom of this page, after describing what the installation is and what it will do to your computer.
+
+# What is conda-forge?
+
+[conda-forge](https://conda-forge.org/) is a "channel" for the [conda](https://docs.conda.io/) package manager containing the Scientific Python ecosystem, Scikit-HEP, and even ROOT (MacOS and Linux) with carefully aligned package versions to ensure that you get a consistent, working system. Within a conda environment, you can still use pip to install packages that are not in this channel, thereby getting access to everything in the [Python Package Index](https://pypi.org/), and everything in the conda environment is kept isolated from any other Python environments, so that you don't disturb any applications that rely on a version of Python that ships with your operating system.
+
+The software in conda-forge are not subject to Anaconda's licensing restrictions, and the conda package manager is free software, so both can be used without any legal restrictions in national labs and universities.
+
+Until recently, the (relatively) [hard part](https://conda-forge.org/docs/user/introduction.html#how-can-i-install-packages-from-conda-forge) had been to ensure that you're using conda-forge, rather than an Anaconda default channel. The instructions below describe how to install [Miniforge](https://github.com/conda-forge/miniforge), which is conda-forge without the Anaconda default channel.
+
+You likely have a package manager for your operating system, such as Homebrew, apt-get, or yum. Use conda for your Python packages and your operating system's package manager for applications (web browsers, text editors, etc.).*
+
+(* I'm doing conda a disservice by describing conda as a Python package manager, though [it does much more](https://jakevdp.github.io/blog/2016/08/25/conda-myths-and-misconceptions/#Myth-#2:-Conda-is-a-Python-package-manager), for the sake of keeping this simple.)
+
+# What is "mamba"?
+
+We recommend using "mamba", which is a drop-in replacement for "conda" that is many times faster. You particularly notice it when a package has many dependencies or complex version constraints on its dependencies.
+
+In fact, the conda developers are [incorporating mamba into conda](https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community), though at the time of this writing, that integration is still experimental. These instructions will describe how to use mamba directly.
+
+# Where will the files go?
+
+The entire Python distribution, with all packages and the shared libraries that support them, will go in a new directory, most likely in your home directory and named `mambaforge`. All of the files in it are installed with your own user permissions (i.e. not superuser/`sudo`).
+
+## How to get rid of them if you change your mind
+
+  1. Delete that directory with `rm -rf ~/mambaforge`.
+  2. Delete a file named `~/.condarc`, if you have one.
+  3. Check your shell configuration file, probably named `~/.bashrc`, for a "`>>> conda initialize`" section. If you have one, delete it.
+
+Those three steps will remove any vestige of the conda installation.
+
+## How to save an old package list before deleting it
+
+If you already have a conda installation, you can bundle your current environment into an environment file with
+
+```bash
+conda env export --from-history > old-environment.yml
+```
+
+After reinstalling, you can reconstruct it with
+
+```bash
+conda env create -f old-environment.yml
+```
+
+# Installing Miniforge
+
+Miniforge is [distributed on GitHub](https://github.com/conda-forge/miniforge).
+
+The steps of the installation procedure are (1) download an installer script, (2) run it, and (3) answer interactive prompts.
+
+Of the four combinations Miniforge gives you (conda vs mamba, Python vs PyPy), [we recommend mamba with Python, which is this table](https://github.com/conda-forge/miniforge#mambaforge).
+
+Within each table is a list of architectures. On Mac and Linux, you can get the name of your architecture from
+
+```bash
+uname -i
+```
+
+It is very likely `x86_64`. Select the installation script for your architecture by clicking or right-clicking the link on the Miniforge page.
+
+On Mac or Linux, run the script with
+
+```bash
+bash filename-of-the-script-you-just-downloaded.sh
+```
+
+Windows has a `start` command; see [Miniforge's instructions](https://github.com/conda-forge/miniforge#windows).
+
+The interactive prompts will ask you where you want to install it (default is `~/mambaforge`) and whether you want to have it enabled whenever you start a new terminal or shell (probably yes). Saying "yes" to the latter inserts a "`>>> conda initialize`" section in your shell configuration (probably `~/.bashrc`).
+
+## Using Miniforge
+
+Now you're ready to go. Instructions online tell you how to install packages, like `conda install package-name`. Since you installed "mamba", you can replace `conda install` with `mamba install` to make the dependency resolution much faster. There are no other differences, and you can always fall back on using the `conda` command.
+
+One of the first commands you'll probably want to do is
+
+```bash
+mamba update --all
+```
+
+Do this approximately once a week, and you'll stay up-to-date on all of your packages. (This updates to the latest _stable_ versions. Bleeding-edge versions would have to be explicitly requested by version number.)
+
+Another good command is
+
+```bash
+mamba clean --all   # or mamba
+```
+
+which removes cached package files (which are not needed, now that they've been installed). Sometimes, you can get gigabytes of disk space back.
+
+## Keeping environments isolated
+
+One of conda's major features is that it allows you to have completely separate Python versions and packages in different "environments." [See conda's documentation](https://docs.conda.io/projects/conda/en/latest/user-guide/getting-started.html#managing-environments) on how to use this feature, especially if you need one project to stay fixed at a specified set of version numbers ("pinned") and another to keep up with the latest updates.

--- a/pages/installing-packages.md
+++ b/pages/installing-packages.md
@@ -157,4 +157,4 @@ which removes cached package files (which are not needed, now that they've been 
 
 One of conda's major features is that it allows you to have completely separate Python versions and packages in different "environments." See [managing environments](https://docs.conda.io/projects/conda/en/latest/user-guide/getting-started.html#managing-environments) in the conda documentation on how to use this feature, especially if you need to switch between projects with different package or version requirements.
 
-**Maintaining separate environments for separate projects is one of our recommended "best practices," whether you're using conda or pip with virtualenv.**
+Maintaining separate environments for separate projects is one of our recommended "best practices," whether you're using conda or pip with virtualenv.

--- a/pages/installing-packages.md
+++ b/pages/installing-packages.md
@@ -13,9 +13,7 @@ If you're having trouble installing Scikit-HEP packages (e.g. `pip install` fail
 
 ![A mess of Python environments](https://imgs.xkcd.com/comics/python_environment.png)
 
-The instructions are at the bottom of this page, after describing what the installation is and what it will do to your computer.
-
-# What is conda-forge?
+<details markdown="1"><summary><h1>What is conda-forge?</h1></summary>
 
 [conda-forge](https://conda-forge.org/) is a "channel" for the [conda](https://docs.conda.io/) package manager containing the Scientific Python ecosystem, Scikit-HEP, and even ROOT (MacOS and Linux) with carefully aligned package versions to ensure that you get a consistent, working system. Within a conda environment, you can still use pip to install packages that are not in this channel, thereby getting access to everything in the [Python Package Index](https://pypi.org/), and everything in the conda environment is kept isolated from any other Python environments, so that you don't disturb any applications that rely on a version of Python that ships with your operating system.
 
@@ -27,17 +25,21 @@ You likely have a package manager for your operating system, such as Homebrew, a
 
 (\* I'm doing conda a disservice by describing conda as a Python package manager, though [it does much more](https://jakevdp.github.io/blog/2016/08/25/conda-myths-and-misconceptions/#Myth-#2:-Conda-is-a-Python-package-manager), for the sake of keeping this simple.)
 
-# What is "mamba"?
+</details>
+
+<details markdown="1"><summary><h1>What is "mamba"?</h1></summary>
 
 We recommend using `mamba`, which is a drop-in replacement for `conda` that is many times faster. You particularly notice it when a package has many dependencies or complex version constraints on its dependencies.
 
 In fact, the conda developers are [incorporating mamba into conda](https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community), though at the time of this writing, that integration is still experimental. These instructions will describe how to use `mamba` directly.
 
-# Where will the files go?
+</details>
+
+<details markdown="1"><summary><h1>Where will the files go?</h1></summary>
 
 The entire Python distribution, with all packages and the shared libraries that support them, will go in a new directory, most likely in your home directory and named `mambaforge`. All of the files in it are installed with your own user permissions (i.e. not superuser/`sudo`).
 
-<details markdown="1"><summary>How to get rid of them if you change your mind (click here)</summary>
+<details markdown="1"><summary><h2>How to get rid of them if you change your mind</h2></summary>
 
 1. Delete that directory with `rm -rf ~/mambaforge`.
 2. Delete a file named `~/.condarc`, if you have one.
@@ -47,7 +49,7 @@ Those three steps will remove any vestige of the conda installation.
 
 </details>
 
-<details markdown="1"><summary>How to save an old package list before deleting it (click here)</summary>
+<details markdown="1"><summary><h2>How to save an old package list before deleting it</h2></summary>
 
 If you already have a conda installation, you can bundle your current environment into an environment file with
 
@@ -63,7 +65,9 @@ conda env create -f old-environment.yml
 
 </details>
 
-# Installing Miniforge
+</details>
+
+# Installing a Python environment with Miniforge
 
 Miniforge is [distributed on GitHub](https://github.com/conda-forge/miniforge).
 
@@ -89,7 +93,7 @@ Windows has a `start` command; see [Miniforge's instructions](https://github.com
 
 The interactive prompts will ask you where you want to install it (default is `~/mambaforge`) and whether you want to have it enabled whenever you start a new terminal or shell (probably yes). Saying "yes" to the latter inserts a "`>>> conda initialize`" section in your shell configuration (probably `~/.bashrc`).
 
-## Using Miniforge
+## Regular maintenance of your environment
 
 Now you're ready to go. Instructions online tell you how to install packages, like `conda install package-name`. Since you installed `mamba`, you can replace `conda install` with `mamba install` to make the dependency resolution much faster. There are no other differences, and you can always fall back on using the `conda` command.
 
@@ -109,6 +113,6 @@ mamba clean --all   # or mamba
 
 which removes cached package files (which are not needed, now that they've been installed). Sometimes, you can get gigabytes of disk space back.
 
-## Keeping environments isolated
+## Leveling up: multiple environments
 
 One of conda's major features is that it allows you to have completely separate Python versions and packages in different "environments." [See conda's documentation](https://docs.conda.io/projects/conda/en/latest/user-guide/getting-started.html#managing-environments) on how to use this feature, especially if you need one project to stay fixed at a specified set of version numbers ("pinned") and another to keep up with the latest updates.

--- a/pages/installing-packages.md
+++ b/pages/installing-packages.md
@@ -9,13 +9,13 @@ nav_order: 35
 
 Many ways to install Python and Python packages have been developed over the years, and not all of them are compatible with each other. Scikit-HEP supports users of the two major systems: (a) pip with virtual environments and (b) conda-forge. For a newcomer, conda-forge is usually the simplest and most reliable way to get started, so we describe that. Also, we describe how to replace `conda` with `mamba` because it is the fastest way to install packages into that environment.
 
-This page is for everyone, but especially newcomers to Python or package management. If, for instance, you're having trouble installing Scikit-HEP packages (e.g. `pip install` fails with an error or you get an `ImportError`/`ModuleNotFoundError`), then this page is for you.
+This page is for everyone, but especially newcomers to Python or package management. If, for instance, you're having trouble installing Scikit-HEP packages—e.g. `pip install` fails with an error or you get an `ImportError`/`ModuleNotFoundError` after you think you've installed it—then this page is for you.
 
 ![A mess of Python environments](https://imgs.xkcd.com/comics/python_environment.png)
 
 <details markdown="1"><summary><h1>What is conda-forge?</h1></summary>
 
-[conda-forge](https://conda-forge.org/) is a "channel" for the [conda](https://docs.conda.io/) package manager containing the Scientific Python ecosystem, Scikit-HEP, and even ROOT (MacOS and Linux) with carefully aligned package versions to ensure that you get a consistent, working system. Within a conda environment, you can still use pip to install packages that are not in this channel, thereby getting access to everything in the [Python Package Index](https://pypi.org/), and everything in the conda environment is kept isolated from all other Python environments, so that you don't disturb any applications that rely on a version of Python that ships with your operating system.
+[conda-forge](https://conda-forge.org/) is a "channel" for the [conda](https://docs.conda.io/) package manager containing the Scientific Python ecosystem, Scikit-HEP, and even [ROOT](https://iris-hep.org/projects/rootconda.html) with carefully aligned package versions to ensure that you get a consistent, working system. Within a conda environment, you can still use pip to install packages that are not in this channel, thereby getting access to everything in the [Python Package Index (PyPI)](https://pypi.org/), and everything in the conda environment is kept isolated from all other Python environments, so that you don't disturb any applications that rely on a version of Python that ships with your operating system.
 
 The software in conda-forge are not subject to Anaconda's licensing restrictions, and the conda package manager is free software, so both can be used without any legal restrictions in national labs and universities.
 
@@ -29,7 +29,7 @@ You likely have a package manager for your operating system, such as Homebrew, a
 
 <details markdown="1"><summary><h1>What is "mamba"?</h1></summary>
 
-We recommend using `mamba`, which is a drop-in replacement for `conda` that is many times faster (in the "solving environment" step). You particularly notice it when a package has many dependencies or complex version constraints on its dependencies.
+We recommend using `mamba`, which is a drop-in replacement for `conda` that is [many times faster](https://wolfv.medium.com/making-conda-fast-again-4da4debfb3b7) (in the "Solving environment: ..." step). You particularly notice it when a package has many dependencies or complex version constraints on its dependencies.
 
 In fact, the conda developers are [incorporating mamba into conda](https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community). At the time of this writing, however, that integration is still experimental. These instructions will describe how to use `mamba` directly.
 
@@ -37,7 +37,7 @@ In fact, the conda developers are [incorporating mamba into conda](https://www.a
 
 <details markdown="1"><summary><h1>Where will the files go?</h1></summary>
 
-The entire Python distribution, with all packages and the binary shared libraries that support them, will go into a new directory, most likely in your home directory and named `mambaforge`. All of the files in it are installed with your own user permissions (i.e. not superuser/`sudo`).
+The entire Python distribution, with all packages and the binary shared libraries that support them, will go into a new directory, most likely in your home directory and named `mambaforge`. All of the files in it are installed with your own user permissions (i.e. not superuser/requiring `sudo`).
 
 <details markdown="1"><summary><h2>How to get rid of them if you change your mind</h2></summary>
 

--- a/pages/installing-packages.md
+++ b/pages/installing-packages.md
@@ -91,7 +91,7 @@ bash filename-of-the-script-you-just-downloaded.sh
 
 Windows has a `start` command; see [Miniforge's instructions](https://github.com/conda-forge/miniforge#windows).
 
-The interactive prompts will ask you where you want to install it (default is `~/mambaforge`) and whether you want to have it enabled whenever you start a new terminal or shell (probably yes). Saying "yes" to the latter inserts a "`>>> conda initialize`" section in your shell configuration (probably `~/.bashrc`).
+The interactive prompts will ask you where you want to install it (default is `~/mambaforge`) and whether you want to have it enabled whenever you start a new terminal or shell (probably "yes"). Saying "yes" to the latter inserts a "`>>> conda initialize`" section in your shell configuration (probably `~/.bashrc`).
 
 <details markdown="1"><summary><h3>Deciding whether conda should take over your shell</h3></summary>
 
@@ -101,7 +101,7 @@ If you say "yes" to let the installer script modify your shell configuation, the
 python
 ```
 
-will run the conda environment's Python, rather than any other Python you have installed. This is what conda calls the "base" environment (though you can create more environments that are independent of this one).
+will run the conda environment's Python, rather than any other Python you have installed on your computer. This is what conda calls the "base" environment (though you can create more environments that are independent of this one).
 
 If, instead, you want to explicitly opt-into conda environments by calling a command, use
 
@@ -117,13 +117,13 @@ conda activate name-of-environment
 
 See [managing environments](https://docs.conda.io/projects/conda/en/latest/user-guide/getting-started.html#managing-environments) in the conda documentation for more.
 
-If you say "no" to not let the installer script modify your shell configuration, then you will have to manually find the path to the `conda` executable, which is in `~/mambaforge/bin/conda`.
+If you say "no" to not let the installer script modify your shell configuration, then you will have to manually find the path to the `conda` executable, which is in `~/mambaforge/bin/conda`. All of the above applies, but your shell might not be able to find `conda` or `python`.
 
 </details>
 
 ## Regular maintenance of the environment
 
-Now you're ready to go. Instructions online tell you how to install packages, like
+Now you're ready to go. [Instructions online](https://docs.conda.io/projects/conda/en/latest/user-guide/cheatsheet.html) tell you how to install packages, like
 
 ```bash
 conda install name-of-package
@@ -156,3 +156,5 @@ which removes cached package files (which are not needed, now that they've been 
 ## Leveling up: multiple environments
 
 One of conda's major features is that it allows you to have completely separate Python versions and packages in different "environments." See [managing environments](https://docs.conda.io/projects/conda/en/latest/user-guide/getting-started.html#managing-environments) in the conda documentation on how to use this feature, especially if you need to switch between projects with different package or version requirements.
+
+**Maintaining separate environments for separate projects is one of our recommended "best practices," whether you're using conda or pip with virtualenv.**

--- a/pages/installing-packages.md
+++ b/pages/installing-packages.md
@@ -7,7 +7,7 @@ nav_order: 35
 
 # Avoiding the spaghetti installation
 
-Many ways to install Python and Python packages have been developed over the years, and not all of them are compatible.
+Many ways to install Python and Python packages have been developed over the years, and not all of them are compatible. We support both major systems: PyPI with virtual environments and conda-forge. For a newcomer, conda-forge is usually the simplest way to start an analysis, so this page covers the best way to set up a working conda-forge environment.
 
 If you're having trouble installing Scikit-HEP packages (e.g. `pip install` fails with an error or you get an `ImportError`/`ModuleNotFoundError`), try following the instructions below to set up a conda-forge environment using `mamba`
 

--- a/pages/installing-packages.md
+++ b/pages/installing-packages.md
@@ -67,9 +67,9 @@ conda env create -f old-environment.yml
 
 </details>
 
-# Installing a Python environment with Miniforge
+# Installing a Python environment
 
-Miniforge is [distributed on GitHub](https://github.com/conda-forge/miniforge).
+We're using Miniforge to install the Python environment, which is [distributed here on GitHub](https://github.com/conda-forge/miniforge).
 
 The steps of the installation procedure are (1) download an installer script, (2) run it, and (3) answer interactive prompts.
 

--- a/pages/installing-packages.md
+++ b/pages/installing-packages.md
@@ -1,11 +1,12 @@
 ---
 layout: page
-title: Installing Python packages with conda-forge
+title: Installing packages
 permalink: /installing-packages
 nav_order: 35
+custom_title: Installing packages with conda-forge
 ---
 
-# Avoiding the spaghetti installation
+## Avoiding the spaghetti installation
 
 Many ways to install Python and Python packages have been developed over the years, and not all of them are compatible with each other. Scikit-HEP supports users of the two major systems: (a) pip with virtual environments and (b) conda-forge. For a newcomer, conda-forge is usually the simplest and most reliable way to get started, so we describe that. Also, we describe how to replace `conda` with `mamba` because it is the fastest way to install packages into that environment.
 
@@ -13,7 +14,7 @@ This page is for everyone, but especially newcomers to Python or package managem
 
 ![A mess of Python environments](https://imgs.xkcd.com/comics/python_environment.png)
 
-<details markdown="1"><summary><h1>What is conda-forge?</h1></summary>
+<details markdown="1"><summary>What is conda-forge? (click here)</summary>
 
 [conda-forge](https://conda-forge.org/) is a "channel" for the [conda](https://docs.conda.io/) package manager containing the Scientific Python ecosystem, Scikit-HEP, and even [ROOT](https://iris-hep.org/projects/rootconda.html) with carefully aligned package versions to ensure that you get a consistent, working system. Within a conda environment, you can still use pip to install packages that are not in this channel, thereby getting access to everything in the [Python Package Index (PyPI)](https://pypi.org/), and everything in the conda environment is kept isolated from all other Python environments, so that you don't disturb any applications that rely on a version of Python that ships with your operating system.
 
@@ -27,7 +28,7 @@ You likely have a package manager for your operating system, such as Homebrew, a
 
 </details>
 
-<details markdown="1"><summary><h1>What is "mamba"?</h1></summary>
+<details markdown="1"><summary>What is "mamba"? (click here)</summary>
 
 We recommend using `mamba`, which is a drop-in replacement for `conda` that is [many times faster](https://wolfv.medium.com/making-conda-fast-again-4da4debfb3b7) (in the "Solving environment: ..." step). You particularly notice it when a package has many dependencies or complex version constraints on its dependencies.
 
@@ -35,11 +36,13 @@ In fact, the conda developers are [incorporating mamba into conda](https://www.a
 
 </details>
 
-<details markdown="1"><summary><h1>Where will the files go?</h1></summary>
+<details markdown="1"><summary>Where will the files go? (click here)</summary>
 
 The entire Python distribution, with all packages and the binary shared libraries that support them, will go into a new directory, most likely in your home directory and named `mambaforge`. All of the files in it are installed with your own user permissions (i.e. not superuser/requiring `sudo`).
 
-<details markdown="1"><summary><h2>How to get rid of them if you change your mind</h2></summary>
+</details>
+
+<details markdown="1"><summary>How to remove conda/mamba cleanly. (click here)</summary>
 
 1. Delete that directory with `rm -rf ~/mambaforge`.
 2. Delete a file named `~/.condarc`, if you have one.
@@ -49,7 +52,7 @@ Those three steps will remove any vestige of the conda installation.
 
 </details>
 
-<details markdown="1"><summary><h2>How to save an old package list before deleting it</h2></summary>
+<details markdown="1"><summary>How to save an old package list before deleting it. (click here)</summary>
 
 If you already have a conda installation, you can bundle your current environment into an environment file (a list of names and versions of packages) with
 
@@ -65,9 +68,7 @@ conda env create -f old-environment.yml
 
 </details>
 
-</details>
-
-# Installing a Python environment
+## Installing a Python environment
 
 We'll be using Miniforge to install the Python environment, which is [distributed here on GitHub](https://github.com/conda-forge/miniforge).
 
@@ -93,7 +94,7 @@ Windows has a `start` command; see [Miniforge's instructions](https://github.com
 
 The interactive prompts will ask you where you want to install it (default is `~/mambaforge`) and whether you want to have it enabled whenever you start a new terminal or shell (probably "yes"). Saying "yes" to the latter inserts a "`>>> conda initialize`" section in your shell configuration (probably `~/.bashrc`).
 
-<details markdown="1"><summary><h3>Deciding whether conda should take over your shell</h3></summary>
+<details markdown="1"><summary>Deciding whether conda should take over your shell? (click here)</summary>
 
 If you say "yes" to let the installer script modify your shell configuration, then the next terminal you open will be in the conda environment. For instance,
 
@@ -157,4 +158,4 @@ which removes cached package files (which are not needed, now that they've been 
 
 One of conda's major features is that it allows you to have completely separate Python versions and packages in different "environments." See [managing environments](https://docs.conda.io/projects/conda/en/latest/user-guide/getting-started.html#managing-environments) in the conda documentation on how to use this feature, especially if you need to switch between projects with different package or version requirements.
 
-Maintaining separate environments for separate projects is one of our recommended "best practices," whether you're using conda or pip with virtualenv.
+Maintaining separate environments for separate projects is one of our recommended "best practices", whether you're using conda or pip with virtualenv.

--- a/pages/installing-packages.md
+++ b/pages/installing-packages.md
@@ -23,9 +23,9 @@ The software in conda-forge are not subject to Anaconda's licensing restrictions
 
 Until recently, the (relatively) [hard part](https://conda-forge.org/docs/user/introduction.html#how-can-i-install-packages-from-conda-forge) had been to ensure that you're using conda-forge, rather than an Anaconda default channel. The instructions below describe how to install [Miniforge](https://github.com/conda-forge/miniforge), which is conda-forge without the Anaconda default channel.
 
-You likely have a package manager for your operating system, such as Homebrew, apt-get, or yum. Use conda for your Python packages and your operating system's package manager for applications (web browsers, text editors, etc.).*
+You likely have a package manager for your operating system, such as Homebrew, apt-get, or yum. Use conda for your Python packages and your operating system's package manager for applications (web browsers, text editors, etc.).\*
 
-(* I'm doing conda a disservice by describing conda as a Python package manager, though [it does much more](https://jakevdp.github.io/blog/2016/08/25/conda-myths-and-misconceptions/#Myth-#2:-Conda-is-a-Python-package-manager), for the sake of keeping this simple.)
+(\* I'm doing conda a disservice by describing conda as a Python package manager, though [it does much more](https://jakevdp.github.io/blog/2016/08/25/conda-myths-and-misconceptions/#Myth-#2:-Conda-is-a-Python-package-manager), for the sake of keeping this simple.)
 
 # What is "mamba"?
 
@@ -39,9 +39,9 @@ The entire Python distribution, with all packages and the shared libraries that 
 
 ## How to get rid of them if you change your mind
 
-  1. Delete that directory with `rm -rf ~/mambaforge`.
-  2. Delete a file named `~/.condarc`, if you have one.
-  3. Check your shell configuration file, probably named `~/.bashrc`, for a "`>>> conda initialize`" section. If you have one, delete it.
+1. Delete that directory with `rm -rf ~/mambaforge`.
+2. Delete a file named `~/.condarc`, if you have one.
+3. Check your shell configuration file, probably named `~/.bashrc`, for a "`>>> conda initialize`" section. If you have one, delete it.
 
 Those three steps will remove any vestige of the conda installation.
 

--- a/pages/installing-packages.md
+++ b/pages/installing-packages.md
@@ -7,15 +7,15 @@ nav_order: 35
 
 # Avoiding the spaghetti installation
 
-Many ways to install Python and Python packages have been developed over the years, and not all of them are compatible. We support both major systems: PyPI with virtual environments and conda-forge. For a newcomer, conda-forge is usually the simplest way to start an analysis, so this page covers the best way to set up a working conda-forge environment.
+Many ways to install Python and Python packages have been developed over the years, and not all of them are compatible with each other. Scikit-HEP supports users of the two major systems: (a) pip with virtual environments and (b) conda-forge. For a newcomer, conda-forge is usually the simplest way to get started, so we describe the most reliable way to set up conda-forge. Also, we describe how to use `mamba` because it is the fastest way to install packages into that environment.
 
-If you're having trouble installing Scikit-HEP packages (e.g. `pip install` fails with an error or you get an `ImportError`/`ModuleNotFoundError`), try following the instructions below to set up a conda-forge environment using `mamba`.
+This page is for everyone, but especially newcomers to Python or package management. If, for instance, you're having trouble installing Scikit-HEP packages (e.g. `pip install` fails with an error or you get an `ImportError`/`ModuleNotFoundError`), then this page is for you.
 
 ![A mess of Python environments](https://imgs.xkcd.com/comics/python_environment.png)
 
 <details markdown="1"><summary><h1>What is conda-forge?</h1></summary>
 
-[conda-forge](https://conda-forge.org/) is a "channel" for the [conda](https://docs.conda.io/) package manager containing the Scientific Python ecosystem, Scikit-HEP, and even ROOT (MacOS and Linux) with carefully aligned package versions to ensure that you get a consistent, working system. Within a conda environment, you can still use pip to install packages that are not in this channel, thereby getting access to everything in the [Python Package Index](https://pypi.org/), and everything in the conda environment is kept isolated from any other Python environments, so that you don't disturb any applications that rely on a version of Python that ships with your operating system.
+[conda-forge](https://conda-forge.org/) is a "channel" for the [conda](https://docs.conda.io/) package manager containing the Scientific Python ecosystem, Scikit-HEP, and even ROOT (MacOS and Linux) with carefully aligned package versions to ensure that you get a consistent, working system. Within a conda environment, you can still use pip to install packages that are not in this channel, thereby getting access to everything in the [Python Package Index](https://pypi.org/), and everything in the conda environment is kept isolated from all other Python environments, so that you don't disturb any applications that rely on a version of Python that ships with your operating system.
 
 The software in conda-forge are not subject to Anaconda's licensing restrictions, and the conda package manager is free software, so both can be used without any legal restrictions in national labs and universities.
 
@@ -23,21 +23,21 @@ Until recently, the (relatively) [hard part](https://conda-forge.org/docs/user/i
 
 You likely have a package manager for your operating system, such as Homebrew, apt-get, or yum. Use conda for your Python packages and your operating system's package manager for applications (web browsers, text editors, etc.).\*
 
-(\* I'm doing conda a disservice by describing conda as a Python package manager, though [it does much more](https://jakevdp.github.io/blog/2016/08/25/conda-myths-and-misconceptions/#Myth-#2:-Conda-is-a-Python-package-manager), for the sake of keeping this simple.)
+(\* We're doing conda a disservice by describing conda as a Python package manager, though [it does much more](https://jakevdp.github.io/blog/2016/08/25/conda-myths-and-misconceptions/#Myth-#2:-Conda-is-a-Python-package-manager), for the sake of keeping this description simple.)
 
 </details>
 
 <details markdown="1"><summary><h1>What is "mamba"?</h1></summary>
 
-We recommend using `mamba`, which is a drop-in replacement for `conda` that is many times faster. You particularly notice it when a package has many dependencies or complex version constraints on its dependencies.
+We recommend using `mamba`, which is a drop-in replacement for `conda` that is many times faster (in the "solving environment" step). You particularly notice it when a package has many dependencies or complex version constraints on its dependencies.
 
-In fact, the conda developers are [incorporating mamba into conda](https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community), though at the time of this writing, that integration is still experimental. These instructions will describe how to use `mamba` directly.
+In fact, the conda developers are [incorporating mamba into conda](https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community). At the time of this writing, however, that integration is still experimental. These instructions will describe how to use `mamba` directly.
 
 </details>
 
 <details markdown="1"><summary><h1>Where will the files go?</h1></summary>
 
-The entire Python distribution, with all packages and the shared libraries that support them, will go in a new directory, most likely in your home directory and named `mambaforge`. All of the files in it are installed with your own user permissions (i.e. not superuser/`sudo`).
+The entire Python distribution, with all packages and the binary shared libraries that support them, will go into a new directory, most likely in your home directory and named `mambaforge`. All of the files in it are installed with your own user permissions (i.e. not superuser/`sudo`).
 
 <details markdown="1"><summary><h2>How to get rid of them if you change your mind</h2></summary>
 
@@ -51,13 +51,13 @@ Those three steps will remove any vestige of the conda installation.
 
 <details markdown="1"><summary><h2>How to save an old package list before deleting it</h2></summary>
 
-If you already have a conda installation, you can bundle your current environment into an environment file with
+If you already have a conda installation, you can bundle your current environment into an environment file (a list of names and versions of packages) with
 
 ```bash
 conda env export --from-history > old-environment.yml
 ```
 
-After reinstalling, you can reconstruct it with
+After setting up a new conda system, you can reinstall all of those packages/versions with
 
 ```bash
 conda env create -f old-environment.yml
@@ -69,11 +69,11 @@ conda env create -f old-environment.yml
 
 # Installing a Python environment
 
-We're using Miniforge to install the Python environment, which is [distributed here on GitHub](https://github.com/conda-forge/miniforge).
+We'll be using Miniforge to install the Python environment, which is [distributed here on GitHub](https://github.com/conda-forge/miniforge).
 
 The steps of the installation procedure are (1) download an installer script, (2) run it, and (3) answer interactive prompts.
 
-Of the four combinations Miniforge gives you (`conda` vs `mamba`, Python vs PyPy), [we recommend mamba with Python, which is this table](https://github.com/conda-forge/miniforge#mambaforge).
+Of the four combinations Miniforge gives you (`conda` vs `mamba`, Python vs PyPy), [we recommend mamba with Python, which is this table](https://github.com/conda-forge/miniforge#mambaforge). (Open that link in a new window.)
 
 Within each table is a list of architectures. On Mac and Linux, you can get the name of your architecture from
 
@@ -93,26 +93,66 @@ Windows has a `start` command; see [Miniforge's instructions](https://github.com
 
 The interactive prompts will ask you where you want to install it (default is `~/mambaforge`) and whether you want to have it enabled whenever you start a new terminal or shell (probably yes). Saying "yes" to the latter inserts a "`>>> conda initialize`" section in your shell configuration (probably `~/.bashrc`).
 
-## Regular maintenance of your environment
+<details markdown="1"><summary><h3>Deciding whether conda should take over your shell</h3></summary>
 
-Now you're ready to go. Instructions online tell you how to install packages, like `conda install package-name`. Since you installed `mamba`, you can replace `conda install` with `mamba install` to make the dependency resolution much faster. There are no other differences, and you can always fall back on using the `conda` command.
+If you say "yes" to let the installer script modify your shell configuation, then the next terminal you open will be in the conda environment. For instance,
 
-One of the first commands you'll probably want to do is
+```bash
+python
+```
+
+will run the conda environment's Python, rather than any other Python you have installed. This is what conda calls the "base" environment (though you can create more environments that are independent of this one).
+
+If, instead, you want to explicitly opt-into conda environments by calling a command, use
+
+```bash
+conda config --set auto_activate_base false
+```
+
+to prevent the "base" environment from being automatically loaded in each new terminal. Now all environments, including "base", have to be explicitly activated with
+
+```bash
+conda activate name-of-environment
+```
+
+See [managing environments](https://docs.conda.io/projects/conda/en/latest/user-guide/getting-started.html#managing-environments) in the conda documentation for more.
+
+If you say "no" to not let the installer script modify your shell configuration, then you will have to manually find the path to the `conda` executable, which is in `~/mambaforge/bin/conda`.
+
+</details>
+
+## Regular maintenance of the environment
+
+Now you're ready to go. Instructions online tell you how to install packages, like
+
+```bash
+conda install name-of-package
+```
+
+Since you installed `mamba`, you can replace `conda install` with `mamba install` to make the dependency resolution much faster.
+
+```bash
+mamba install name-of-package   # fast!
+```
+
+There are no other differences, and you can always fall back on using the `conda` command. (Necessary, for instance, in `conda activate name-of-environment`.)
+
+One of the first commands you should do after installation is
 
 ```bash
 mamba update --all
 ```
 
-Do this approximately once a week, and you'll stay up-to-date on all of your packages. (This updates to the latest _stable_ versions. Bleeding-edge versions would have to be explicitly requested by version number.)
+to get the newest versions of all the installed packages (newer than the installation script). Then do this approximately once a week to stay up-to-date on all of your packages. (This command updates to the latest _stable_ versions, not bleeding-edge versions unless you explicitly request them by version number.)
 
 Another good command is
 
 ```bash
-mamba clean --all   # or mamba
+mamba clean --all
 ```
 
 which removes cached package files (which are not needed, now that they've been installed). Sometimes, you can get gigabytes of disk space back.
 
 ## Leveling up: multiple environments
 
-One of conda's major features is that it allows you to have completely separate Python versions and packages in different "environments." [See conda's documentation](https://docs.conda.io/projects/conda/en/latest/user-guide/getting-started.html#managing-environments) on how to use this feature, especially if you need one project to stay fixed at a specified set of version numbers ("pinned") and another to keep up with the latest updates.
+One of conda's major features is that it allows you to have completely separate Python versions and packages in different "environments." See [managing environments](https://docs.conda.io/projects/conda/en/latest/user-guide/getting-started.html#managing-environments) in the conda documentation on how to use this feature, especially if you need to switch between projects with different package or version requirements.

--- a/pages/installing-packages.md
+++ b/pages/installing-packages.md
@@ -11,7 +11,7 @@ Many ways to install Python and Python packages have been developed over the yea
 
 This page is for everyone, but especially newcomers to Python or package management. If, for instance, you're having trouble installing Scikit-HEP packages (e.g. `pip install` fails with an error or you get an `ImportError`/`ModuleNotFoundError`), then this page is for you.
 
-<img src="https://imgs.xkcd.com/comics/python_environment.png" alt="A mess of Python environments" style="margin-left: auto; margin-right: auto;">
+![A mess of Python environments](https://imgs.xkcd.com/comics/python_environment.png)
 
 <details markdown="1"><summary><h1>What is conda-forge?</h1></summary>
 

--- a/pages/installing-packages.md
+++ b/pages/installing-packages.md
@@ -11,9 +11,7 @@ Many ways to install Python and Python packages have been developed over the yea
 
 This page is for everyone, but especially newcomers to Python or package management. If, for instance, you're having trouble installing Scikit-HEP packages (e.g. `pip install` fails with an error or you get an `ImportError`/`ModuleNotFoundError`), then this page is for you.
 
-<center>
-  <img src="https://imgs.xkcd.com/comics/python_environment.png" alt="A mess of Python environments">
-</center>
+<img src="https://imgs.xkcd.com/comics/python_environment.png" alt="A mess of Python environments" style="margin-left: auto; margin-right: auto;">
 
 <details markdown="1"><summary><h1>What is conda-forge?</h1></summary>
 

--- a/pages/installing-packages.md
+++ b/pages/installing-packages.md
@@ -95,7 +95,7 @@ The interactive prompts will ask you where you want to install it (default is `~
 
 <details markdown="1"><summary><h3>Deciding whether conda should take over your shell</h3></summary>
 
-If you say "yes" to let the installer script modify your shell configuation, then the next terminal you open will be in the conda environment. For instance,
+If you say "yes" to let the installer script modify your shell configuration, then the next terminal you open will be in the conda environment. For instance,
 
 ```bash
 python

--- a/pages/installing-packages.md
+++ b/pages/installing-packages.md
@@ -9,7 +9,7 @@ nav_order: 35
 
 Many ways to install Python and Python packages have been developed over the years, and not all of them are compatible.
 
-If you're having trouble installing Scikit-HEP packages (e.g. `pip install` fails with an error or you get an `ImportError`/`ModuleNotFoundError`), try following the instructions below to set up a conda-forge environment.
+If you're having trouble installing Scikit-HEP packages (e.g. `pip install` fails with an error or you get an `ImportError`/`ModuleNotFoundError`), try following the instructions below to set up a conda-forge environment using `mamba`
 
 ![A mess of Python environments](https://imgs.xkcd.com/comics/python_environment.png)
 

--- a/pages/installing-packages.md
+++ b/pages/installing-packages.md
@@ -37,13 +37,15 @@ In fact, the conda developers are [incorporating mamba into conda](https://www.a
 
 The entire Python distribution, with all packages and the shared libraries that support them, will go in a new directory, most likely in your home directory and named `mambaforge`. All of the files in it are installed with your own user permissions (i.e. not superuser/`sudo`).
 
-## How to get rid of them if you change your mind
+<details markdown="1"><summary> How to get rid of them if you change your mind (click here)</summary>
 
 1. Delete that directory with `rm -rf ~/mambaforge`.
 2. Delete a file named `~/.condarc`, if you have one.
 3. Check your shell configuration file, probably named `~/.bashrc`, for a "`>>> conda initialize`" section. If you have one, delete it.
 
 Those three steps will remove any vestige of the conda installation.
+
+</details>
 
 ## How to save an old package list before deleting it
 

--- a/pages/installing-packages.md
+++ b/pages/installing-packages.md
@@ -7,11 +7,13 @@ nav_order: 35
 
 # Avoiding the spaghetti installation
 
-Many ways to install Python and Python packages have been developed over the years, and not all of them are compatible with each other. Scikit-HEP supports users of the two major systems: (a) pip with virtual environments and (b) conda-forge. For a newcomer, conda-forge is usually the simplest way to get started, so we describe the most reliable way to set up conda-forge. Also, we describe how to use `mamba` because it is the fastest way to install packages into that environment.
+Many ways to install Python and Python packages have been developed over the years, and not all of them are compatible with each other. Scikit-HEP supports users of the two major systems: (a) pip with virtual environments and (b) conda-forge. For a newcomer, conda-forge is usually the simplest and most reliable way to get started, so we describe that. Also, we describe how to replace `conda` with `mamba` because it is the fastest way to install packages into that environment.
 
 This page is for everyone, but especially newcomers to Python or package management. If, for instance, you're having trouble installing Scikit-HEP packages (e.g. `pip install` fails with an error or you get an `ImportError`/`ModuleNotFoundError`), then this page is for you.
 
-![A mess of Python environments](https://imgs.xkcd.com/comics/python_environment.png)
+<center>
+  <img src="https://imgs.xkcd.com/comics/python_environment.png" alt="A mess of Python environments">
+</center>
 
 <details markdown="1"><summary><h1>What is conda-forge?</h1></summary>
 

--- a/pages/user/index.md
+++ b/pages/user/index.md
@@ -8,6 +8,6 @@ has_children: true
 
 The pages here are intended for users of the scikit-hep packages.
 
-Currently, we have a page on [Conda installation instructions][installing conda].
+If you're having trouble installing Python packages or using ROOT with Scikit-HEP packages, see our [Conda installation instructions](Conda installation instructions).
 
 [installing-conda]: {{ site.baseurl }}{% link pages/user/installing-conda.md %}

--- a/pages/user/index.md
+++ b/pages/user/index.md
@@ -1,0 +1,14 @@
+---
+layout: page
+title: User information
+permalink: /user
+nav_order: 79
+has_children: true
+---
+
+The pages here are intended for users of the scikit-hep packages.
+
+Currently, we have a page on [Conda installation instructions][installing conda].
+
+[installing-conda]: {{ site.baseurl }}{% link pages/user/installing-conda.md %}
+

--- a/pages/user/index.md
+++ b/pages/user/index.md
@@ -11,4 +11,3 @@ The pages here are intended for users of the scikit-hep packages.
 Currently, we have a page on [Conda installation instructions][installing conda].
 
 [installing-conda]: {{ site.baseurl }}{% link pages/user/installing-conda.md %}
-

--- a/pages/user/installing-conda.md
+++ b/pages/user/installing-conda.md
@@ -14,7 +14,7 @@ This page is for everyone, but especially newcomers to Python or package managem
 
 ![A mess of Python environments](https://imgs.xkcd.com/comics/python_environment.png)
 
-<details markdown="1"><summary>What is conda-forge? (click here)</summary>
+<details markdown="1"><summary>What is conda-forge?</summary>
 
 [conda-forge](https://conda-forge.org/) is a "channel" for the [conda](https://docs.conda.io/) package manager containing the Scientific Python ecosystem, Scikit-HEP, and even [ROOT](https://iris-hep.org/projects/rootconda.html) with carefully aligned package versions to ensure that you get a consistent, working system. Within a conda environment, you can still use pip to install packages that are not in this channel, thereby getting access to everything in the [Python Package Index (PyPI)](https://pypi.org/), and everything in the conda environment is kept isolated from all other Python environments, so that you don't disturb any applications that rely on a version of Python that ships with your operating system.
 
@@ -28,7 +28,7 @@ You likely have a package manager for your operating system, such as Homebrew, a
 
 </details>
 
-<details markdown="1"><summary>What is "mamba"? (click here)</summary>
+<details markdown="1"><summary>What is "mamba"?</summary>
 
 We recommend using `mamba`, which is a drop-in replacement for `conda` that is [many times faster](https://wolfv.medium.com/making-conda-fast-again-4da4debfb3b7) (in the "Solving environment: ..." step). You particularly notice it when a package has many dependencies or complex version constraints on its dependencies.
 
@@ -36,13 +36,13 @@ In fact, the conda developers are [incorporating mamba into conda](https://www.a
 
 </details>
 
-<details markdown="1"><summary>Where will the files go? (click here)</summary>
+<details markdown="1"><summary>Where will the files go?</summary>
 
 The entire Python distribution, with all packages and the binary shared libraries that support them, will go into a new directory, most likely in your home directory and named `mambaforge`. All of the files in it are installed with your own user permissions (i.e. not superuser/requiring `sudo`).
 
 </details>
 
-<details markdown="1"><summary>How to remove conda/mamba cleanly. (click here)</summary>
+<details markdown="1"><summary>How to remove conda/mamba cleanly.</summary>
 
 1. Delete that directory with `rm -rf ~/mambaforge`.
 2. Delete a file named `~/.condarc`, if you have one.
@@ -52,7 +52,7 @@ Those three steps will remove any vestige of the conda installation.
 
 </details>
 
-<details markdown="1"><summary>How to save an old package list before deleting it. (click here)</summary>
+<details markdown="1"><summary>How to save an old package list before deleting it.</summary>
 
 If you already have a conda installation, you can bundle your current environment into an environment file (a list of names and versions of packages) with
 
@@ -94,7 +94,7 @@ Windows has a `start` command; see [Miniforge's instructions](https://github.com
 
 The interactive prompts will ask you where you want to install it (default is `~/mambaforge`) and whether you want to have it enabled whenever you start a new terminal or shell (probably "yes"). Saying "yes" to the latter inserts a "`>>> conda initialize`" section in your shell configuration (probably `~/.bashrc`).
 
-<details markdown="1"><summary>Deciding whether conda should take over your shell? (click here)</summary>
+<details markdown="1"><summary>Deciding whether conda should take over your shell?</summary>
 
 If you say "yes" to let the installer script modify your shell configuration, then the next terminal you open will be in the conda environment. For instance,
 

--- a/pages/user/installing-conda.md
+++ b/pages/user/installing-conda.md
@@ -12,7 +12,7 @@ Many ways to install Python and Python packages have been developed over the yea
 
 This page is for everyone, but especially newcomers to Python or package management. If, for instance, you're having trouble installing Scikit-HEP packages—e.g. `pip install` fails with an error or you get an `ImportError`/`ModuleNotFoundError` after you think you've installed it—then this page is for you.
 
-![A mess of Python environments](https://imgs.xkcd.com/comics/python_environment.png)
+<img src="https://imgs.xkcd.com/comics/python_environment.png" alt="A mess of Python environments" style="border: solid white 3px; display: block; margin-left: auto; margin-right: auto;">
 
 <details markdown="1"><summary>What is conda-forge?</summary>
 

--- a/pages/user/installing-conda.md
+++ b/pages/user/installing-conda.md
@@ -1,9 +1,9 @@
 ---
 layout: page
-title: Installing packages
-permalink: /installing-packages
-nav_order: 35
-custom_title: Installing packages with conda-forge
+title: Installing conda
+permalink: /user/installing-conda
+nav_order: 10
+parent: User information
 ---
 
 ## Avoiding the spaghetti installation


### PR DESCRIPTION
This is a question that @eduardo-rodrigues, @henryiii, @chrisburr, @HDembinski may want to weigh in on: whether we, as Scikit-HEP, should endorse Miniforge as the recommended way to install Python packages. I know that we have different preferences, but in my experience with tutoring, getting users started has been easiest with a conda environment, and now Miniforge even removes the aspect of having to change channels and be sure that conda-forge doesn't get mixed in with the default channel.

I was prompted to make this pull request by a [conversation on Slack](https://iris-hep.slack.com/archives/CFEK2FECR/p1652371587328839) (link will only work if you're on IRIS-HEP's Slack). The people involved in that conversation were @alexander-held, @kpedro88, @Moelf, @matthewfeickert, @agoose77, @NJManganelli, @PerilousApricot, @tacaswell. (If you want to unwatch this PR, feel free to!)

I welcome any direct edits to this PR if you want to change anything.