### PR TITLE
fix: correcting usage of setup-python

### DIFF
--- a/pages/developers/gha_basic.md
+++ b/pages/developers/gha_basic.md
@@ -56,6 +56,8 @@ lint:
   steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
+      with:
+        python-version: "3.x"
     - uses: pre-commit/action@v3.0.0
 ```
 


### PR DESCRIPTION
This was incorrectly updated; setup-python v4 breaks "simple" usage and always requires a `python-version` now. For now, let's add the manual setting unless https://github.com/actions/setup-python/issues/421 ends up re-adding a default (which I'd really love to see, as this was handy and much simpler).