### PR TITLE
feat: Add 'name-tests-test' to pre-commit hooks example

### DIFF
--- a/pages/developers/style.md
+++ b/pages/developers/style.md
@@ -26,7 +26,7 @@ Here is a minimal `.pre-commit-config.yaml` file with some handy options:
 ```yaml
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: "v4.2.0"
+    rev: "v4.3.0"
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict

--- a/pages/developers/style.md
+++ b/pages/developers/style.md
@@ -36,6 +36,8 @@ repos:
       - id: debug-statements
       - id: end-of-file-fixer
       - id: mixed-line-ending
+      - id: name-tests-test
+        args: ["--pytest-test-first"]
       - id: requirements-txt-fixer
       - id: trailing-whitespace
 ```


### PR DESCRIPTION
Resolves #227

* Update pre-commit/pre-commit-hooks example to v4.3.0
* Add the 'name-tests-test' pre-commit hooks which verifies that test files under `tests/` conform to `pytest` naming conventions.
   - Use the `--pytest-test-first` option to match the `test_.*\.py` naming convention.