### PR TITLE
chore: update actions/dependabot

### DIFF
--- a/pages/developers/gha_basic.md
+++ b/pages/developers/gha_basic.md
@@ -174,7 +174,7 @@ Later steps will see this environment variable.
 
 There are a variety of useful actions. There are GitHub supplied ones:
 
-- [actions/checkout](https://github.com/actions/checkout): Almost always the first action. v2/3 does not keep Git history unless `with: fetch-depth: 0` is included (important for SCM versioning). v1 works on very old docker images.
+- [actions/checkout](https://github.com/actions/checkout): Almost always the first action. v2+ does not keep Git history unless `with: fetch-depth: 0` is included (important for SCM versioning). v1 works on very old docker images.
 - [actions/setup-python](https://github.com/actions/setup-python): Do not use v1; v2+ can setup any Python, including uninstalled ones and pre-releases. v4 requires a Python version to be selected.
 - [actions/cache](https://github.com/actions/cache): Can store files and restore them on future runs, with a settable key.
 - [actions/upload-artifact](https://github.com/actions/upload-artifact): Upload a file to be accessed from the UI or from a later job.

--- a/pages/developers/gha_basic.md
+++ b/pages/developers/gha_basic.md
@@ -93,7 +93,7 @@ tests:
   steps:
     - uses: actions/checkout@v3
       with:
-        fetch-depth: 0 # Only needed if using setuptools-scm
+        fetch-depth: 0  # Only needed if using setuptools-scm
 
     - name: Setup Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
@@ -135,20 +135,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    ignore:
-      # Official actions have moving tags like v1
-      - dependency-name: "actions/*"
-        update-types:
-          ["version-update:semver-minor", "version-update:semver-patch"]
 ```
 
-As shown above, you can ignore certain dependencies (all or just updates, like
-minor/patch) - this file ignores any official action minor/patch, because they
-are very reliable in keeping a `vX` tag that moves and points at the latests
-`vX.Y.Z` release, and API is stable between major versions. For all other
-actions, this will check to see if there are updates to the action daily, and
+This will check to see if there are updates to the action weekly, and
 will make a PR if there are updates, including the changelog and commit summary
-in the PR.
+in the PR. If you select a name like `v1`, this should only look for updates
+of the same form (since April 2022) - there is no need to restrict updates for
+"moving tag" updates anymore. You can also use SHA's and dependabot will
+respect that too.
 
 You can use this for other ecosystems too, including Python.
 
@@ -180,10 +174,10 @@ Later steps will see this environment variable.
 
 There are a variety of useful actions. There are GitHub supplied ones:
 
-- [actions/checkout](https://github.com/actions/checkout): Almost always the first action. v2/3 does not keep Git history unless `with: fetch-depth: 0` is included.
-- [actions/setup-python](https://github.com/actions/setup-python): Do not use v1; v2/3 can setup any Python, including uninstalled ones and pre-releases.
-- [actions/cache](https://github.com/actions/cache): Can store files and restore them on future runs, with a settable key. Use v2.
-- [actions/upload-artifact](https://github.com/actions/upload-artifact): Upload a file to be accessed from the UI or from a later job. Use v2/3.
+- [actions/checkout](https://github.com/actions/checkout): Almost always the first action. v2/3 does not keep Git history unless `with: fetch-depth: 0` is included (important for SCM versioning). v1 works on very old docker images.
+- [actions/setup-python](https://github.com/actions/setup-python): Do not use v1; v2+ can setup any Python, including uninstalled ones and pre-releases. v4 requires a Python version to be selected.
+- [actions/cache](https://github.com/actions/cache): Can store files and restore them on future runs, with a settable key.
+- [actions/upload-artifact](https://github.com/actions/upload-artifact): Upload a file to be accessed from the UI or from a later job.
 - [actions/download-artifact](https://github.com/actions/download-artifact): Download a file that was previously uploaded, often for releasing. Match upload-artifact version.
 
 And many other useful ones:
@@ -223,10 +217,10 @@ If you add the following, you can ensure only one run per PR/branch happens at a
 
 ```yaml
 concurrency:
-  group: test-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 ```
 
 {% endraw %}
 
-Anything with a matching group name will count in the same group - the ref is the "from" name for the PR.
+Anything with a matching group name will count in the same group - the ref is the "from" name for the PR. If you want, you can replace `github.ref` with `github.event.pull_request.number || github.sha`; this will still cancel on PR pushes but will build each commit on `main`.

--- a/pages/developers/gha_basic.md
+++ b/pages/developers/gha_basic.md
@@ -93,7 +93,7 @@ tests:
   steps:
     - uses: actions/checkout@v3
       with:
-        fetch-depth: 0  # Only needed if using setuptools-scm
+        fetch-depth: 0 # Only needed if using setuptools-scm
 
     - name: Setup Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4


### PR DESCRIPTION
It is no longer required to specify dependabot ignore official action minor/patch versions, as it now keeps the style you are using. Also improving the specification of cancellation.