### PR TITLE
feat: add a developers page on coverage and codecov

### DIFF
--- a/pages/developers/badges.md
+++ b/pages/developers/badges.md
@@ -66,7 +66,7 @@ wget -O Scikit--HEP-Project-blue.svg 'https://img.shields.io/badge/Scikit--HEP-P
 
 ## Other projects
 
-It is highly recommended you have the PyPI and Conda-Forge badges (if applicable). Tests, docs, and Zenodo DOI are generally recommended as well.
+It is highly recommended you have the PyPI and Conda-Forge badges (if applicable). Tests, coverage (codecov, if applicable), docs, and Zenodo DOI are generally recommended as well.
 
 <script>
 function openTab(tabName) {

--- a/pages/developers/coverage.md
+++ b/pages/developers/coverage.md
@@ -74,8 +74,8 @@ codecov:
 
 where `x` is the number of uploaded reports `Codecov` should wait to receive before sending statuses. This would ensure that the `Codecov` checks don't fail before all the coverage reports are uploaded. See the [docs](https://docs.codecov.com/docs/codecov-yaml) for all the options.
 
-### Coverage for projects written in Python and C++
+<!-- ### Coverage for projects written in Python and C++
 
-<!-- TODO -->
+TODO -->
 
 [codecov/codecov-action]: https://github.com/codecov/codecov-action

--- a/pages/developers/coverage.md
+++ b/pages/developers/coverage.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: "Code coverage with pytest-cov and Codecov"
+title: "Code coverage"
 permalink: /developer/coverage
 nav_order: 4
 parent: Developer information
@@ -38,7 +38,7 @@ python -m pytest -ra --cov=vector tests/
 
 Your workflows should also run tests with the `--cov` option, which must be set to your package name. For example -
 
-```
+```yaml
 - name: Test package
   run: python -m pytest -ra --cov=vector tests/
 ```
@@ -53,7 +53,7 @@ All the `Scikit-HEP` projects using `Codecov`, with detailed coverage reports an
 
 Codecov maintains the [codecov/codecov-action](https://github.com/codecov/codecov-action) GitHub Action to make uploading coverage reports easy for users. A minimal working example for uploading coverage reports through your workflow, which should be more than enough for a simple testing suite, can be written as follows -
 
-```
+```yaml
 - name: Upload coverage report
   uses: codecov/codecov-action@v3.1.0
 ```

--- a/pages/developers/coverage.md
+++ b/pages/developers/coverage.md
@@ -64,7 +64,7 @@ The lines above should be added after the step that runs your tests with the `--
 
 One can also configure `Codecov` and coverage reports passed to `Codecov` using `codecov.yml`. `codecov.yml` should be placed inside the `.github` folder, along with your `workflows` folder. Additionally, `Codecov` allows you to create and edit this `YAML` file directly through your `Codecov` project's settings!
 
-A recommended configuration for `Codecov` -
+A recommended configuration for `Codecov`:
 
 ```yaml
 codecov:

--- a/pages/developers/coverage.md
+++ b/pages/developers/coverage.md
@@ -8,7 +8,7 @@ parent: Developer information
 
 {% include toc.html %}
 
-The "Code coverage" value of a codebase indicates how much of the production/development code is covered by the running unit tests. Maintainers try their best to keep this percentage high, and this process is often automated using tools like `GitHub Actions` and `Codecov`. Hence, code coverage becomes a good metric (not always) to check if a particular codebase is well tested and reliable.
+The "Code coverage" value of a codebase indicates how much of the production/development code is covered by the running unit tests. Maintainers try their best to keep this percentage high, and this process is often automated using tools such as `GitHub Actions` and `Codecov`. Hence, code coverage becomes a good metric (not always) to check if a particular codebase is well tested and reliable.
 
 Tools and libraries used to calculate, read, and visualize coverage reports:
 

--- a/pages/developers/coverage.md
+++ b/pages/developers/coverage.md
@@ -51,7 +51,7 @@ Interestingly, `Codecov` does not require any initial configurations for your pr
 
 All `Scikit-HEP` packages using `Codecov`, with detailed coverage reports and graphs, are available at [https://app.codecov.io/gh/scikit-hep](https://app.codecov.io/gh/scikit-hep). After your workflows push your first coverage report to `Codecov` your repository should also appear here.
 
-Codecov maintains the [codecov/codecov-action][] GitHub Action to make uploading coverage reports easy for users. A minimal working example for uploading coverage reports through your workflow, which should be more than enough for a simple testing suite, can be written as follows -
+`Codecov` maintains the [codecov/codecov-action][] GitHub Action to make uploading coverage reports easy for users. A minimal working example for uploading coverage reports through your workflow, which should be more than enough for a simple testing suite, can be written as follows:
 
 ```yaml
 - name: Upload coverage report

--- a/pages/developers/coverage.md
+++ b/pages/developers/coverage.md
@@ -1,0 +1,78 @@
+---
+layout: page
+title: "Code coverage with pytest-cov and Codecov"
+permalink: /developer/coverage
+nav_order: 4
+parent: Developer information
+---
+
+{% include toc.html %}
+
+The "Code coverage" value of a codebase indicates how much of the production/development code is covered by the running unit tests. Maintainers try their best to keep this percentage high, and this process is often automated using tools like `GitHub Actions` and `Codecov`. Hence, code coverage becomes a good metric (not always) to check if a particular codebase is well tested and reliable.
+
+Tools and libraries used to calculate, read, and visualize coverage reports:
+- `pytest-cov`: allows developers to calculate and visualize the coverage value
+- `Codecov`: integrates with remote repositories, allowing developers to see and compare coverage value with each CI run
+- `GitHub Actions`: allows users to automatically upload coverage reports to `Codecov`
+
+> ### Are there any alternatives?
+>
+> `coverage.py` is a popular Python library used to calculate coverage values, but it is usually paired with python's `unittest`. On the other hand, `pytest-cov` is built to integrate with `pytest` with minimal extra configurations. Further, Coveralls is an alternative coverage platform, but we recommend using Codecov because of its ease of use and integration with GitHub Actions.
+
+> ### Should increasing the coverage value be my top priority?
+>
+> A low coverage percentage will definitely motivate you to add more tests, but adding weak tests just for coverage's sake is not a good idea. The tests should test your codebase thoroughly and should not be unreliable.
+
+### Calculating code coverage locally
+
+`pytest` allows users to pass the `--cov` option to automatically invoke `pytest-cov`, which then generates a `.coverage` file with the calculated coverage value. The value of `--cov` option should be set to the name of your package. For example, run the following command to run tests to generate a `.coverage` file for the vector package -
+
+```
+python -m pytest -ra --cov=vector tests/
+```
+
+`--cov` option would also print a minimal coverage report in the terminal itself! See the [docs](https://pytest-cov.readthedocs.io/en/latest/) for more options.
+
+### Calculating code coverage in your workflows
+
+Your workflows should also run tests with the `--cov` option, which must be set to your package name. For example -
+
+```
+- name: Test package
+  run: python -m pytest -ra --cov=vector tests/
+```
+
+This will automatically invoke `pytest-cov`, and generate a `.coverage` file, which can then be uploaded to `Codecov` using the [codecov/codecov-action](https://github.com/codecov/codecov-action) action.
+
+### Configuring Codecov and uploading coverage reports
+
+Interestingly, `Codecov` does not require any initial configurations for your project, given that you have already signed up for the same using your GitHub account. `Codecov` requires you to push or upload your coverage report, after which it automatically generates a `Codecov` project for you.
+
+All the `Scikit-HEP` projects using `Codecov`, with detailed coverage reports and graphs, are available here - [https://app.codecov.io/gh/scikit-hep](https://app.codecov.io/gh/scikit-hep). After your workflows push your first coverage report to `Codecov` your repository should also appear here.
+
+Codecov maintains the [codecov/codecov-action](https://github.com/codecov/codecov-action) GitHub Action to make uploading coverage reports easy for users. A minimal working example for uploading coverage reports through your workflow, which should be more than enough for a simple testing suite, can be written as follows -
+
+```
+- name: Upload coverage report
+  uses: codecov/codecov-action@v3.1.0
+```
+
+The lines above should be added after the step that runs your tests with the `--cov` option. See the [docs](https://github.com/codecov/codecov-action#usage) for all the optional options.
+
+### Using codecov.yml
+
+One can also configure `Codecov` and coverage reports passed to `Codecov` using `codecov.yml`. `codecov.yml` should be placed inside the `.github` folder, along with your `workflows` folder. Additionally, `Codecov` allows you to create and edit this `YAML` file directly through your `Codecov` project's settings!
+
+A recommended configuration for `Codecov` -
+
+```yaml
+codecov:
+  notify:
+    after_n_builds: x
+```
+
+where `x` is the number of uploaded reports `Codecov` should wait to receive before sending statuses. This would ensure that the `Codecov` checks don't fail before all the coverage reports are uploaded. See [docs](https://docs.codecov.com/docs/codecov-yaml) for all the options.
+
+### Coverage for projects written in Python and C++
+
+<!-- TODO -->

--- a/pages/developers/coverage.md
+++ b/pages/developers/coverage.md
@@ -11,6 +11,7 @@ parent: Developer information
 The "Code coverage" value of a codebase indicates how much of the production/development code is covered by the running unit tests. Maintainers try their best to keep this percentage high, and this process is often automated using tools like `GitHub Actions` and `Codecov`. Hence, code coverage becomes a good metric (not always) to check if a particular codebase is well tested and reliable.
 
 Tools and libraries used to calculate, read, and visualize coverage reports:
+
 - `pytest-cov`: allows developers to calculate and visualize the coverage value
 - `Codecov`: integrates with remote repositories, allowing developers to see and compare coverage value with each CI run
 - `GitHub Actions`: allows users to automatically upload coverage reports to `Codecov`

--- a/pages/developers/coverage.md
+++ b/pages/developers/coverage.md
@@ -32,7 +32,7 @@ Tools and libraries used to calculate, read, and visualize coverage reports:
 python -m pytest -ra --cov=vector tests/
 ```
 
-`--cov` option would also print a minimal coverage report in the terminal itself! See the [docs](https://pytest-cov.readthedocs.io/en/latest/) for more options.
+`--cov` option will also print a minimal coverage report in the terminal itself! See the [docs](https://pytest-cov.readthedocs.io/en/latest/) for more options.
 
 ### Calculating code coverage in your workflows
 

--- a/pages/developers/coverage.md
+++ b/pages/developers/coverage.md
@@ -49,7 +49,7 @@ This will automatically invoke `pytest-cov`, and generate a `.coverage` file, wh
 
 Interestingly, `Codecov` does not require any initial configurations for your project, given that you have already signed up for the same using your GitHub account. `Codecov` requires you to push or upload your coverage report, after which it automatically generates a `Codecov` project for you.
 
-All the `Scikit-HEP` projects using `Codecov`, with detailed coverage reports and graphs, are available here - [https://app.codecov.io/gh/scikit-hep](https://app.codecov.io/gh/scikit-hep). After your workflows push your first coverage report to `Codecov` your repository should also appear here.
+All `Scikit-HEP` packages using `Codecov`, with detailed coverage reports and graphs, are available at [https://app.codecov.io/gh/scikit-hep](https://app.codecov.io/gh/scikit-hep). After your workflows push your first coverage report to `Codecov` your repository should also appear here.
 
 Codecov maintains the [codecov/codecov-action][] GitHub Action to make uploading coverage reports easy for users. A minimal working example for uploading coverage reports through your workflow, which should be more than enough for a simple testing suite, can be written as follows -
 

--- a/pages/developers/coverage.md
+++ b/pages/developers/coverage.md
@@ -43,7 +43,7 @@ Your workflows should also run tests with the `--cov` option, which must be set 
   run: python -m pytest -ra --cov=vector tests/
 ```
 
-This will automatically invoke `pytest-cov`, and generate a `.coverage` file, which can then be uploaded to `Codecov` using the [codecov/codecov-action](https://github.com/codecov/codecov-action) action.
+This will automatically invoke `pytest-cov`, and generate a `.coverage` file, which can then be uploaded to `Codecov` using the [codecov/codecov-action][] action.
 
 ### Configuring Codecov and uploading coverage reports
 
@@ -51,7 +51,7 @@ Interestingly, `Codecov` does not require any initial configurations for your pr
 
 All the `Scikit-HEP` projects using `Codecov`, with detailed coverage reports and graphs, are available here - [https://app.codecov.io/gh/scikit-hep](https://app.codecov.io/gh/scikit-hep). After your workflows push your first coverage report to `Codecov` your repository should also appear here.
 
-Codecov maintains the [codecov/codecov-action](https://github.com/codecov/codecov-action) GitHub Action to make uploading coverage reports easy for users. A minimal working example for uploading coverage reports through your workflow, which should be more than enough for a simple testing suite, can be written as follows -
+Codecov maintains the [codecov/codecov-action][] GitHub Action to make uploading coverage reports easy for users. A minimal working example for uploading coverage reports through your workflow, which should be more than enough for a simple testing suite, can be written as follows -
 
 ```yaml
 - name: Upload coverage report
@@ -72,8 +72,10 @@ codecov:
     after_n_builds: x
 ```
 
-where `x` is the number of uploaded reports `Codecov` should wait to receive before sending statuses. This would ensure that the `Codecov` checks don't fail before all the coverage reports are uploaded. See [docs](https://docs.codecov.com/docs/codecov-yaml) for all the options.
+where `x` is the number of uploaded reports `Codecov` should wait to receive before sending statuses. This would ensure that the `Codecov` checks don't fail before all the coverage reports are uploaded. See the [docs](https://docs.codecov.com/docs/codecov-yaml) for all the options.
 
 ### Coverage for projects written in Python and C++
 
 <!-- TODO -->
+
+[codecov/codecov-action]: https://github.com/codecov/codecov-action


### PR DESCRIPTION
This was long due!

The "Coverage for projects written in Python and C++" section is empty right now, and I think it would be better if someone experienced could write that section. I have never done any coverage stuff on projects using Python and C++, but I can take up a more days and learn it on a dummy project.

cc: @henryiii @amangoel185  