### PR TITLE
feat: add git archive support for auto versioning

### DIFF
--- a/pages/developers/packaging.md
+++ b/pages/developers/packaging.md
@@ -203,7 +203,7 @@ You should also add these two files:
 ```text
 node: $Format:%H$
 node-date: $Format:%cI$
-describe-name: $Format:%(describe)$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$
 ref-names: $Format:%D$
 ```
 

--- a/pages/developers/packaging.md
+++ b/pages/developers/packaging.md
@@ -196,7 +196,6 @@ run, that version will be forced, otherwise, it works as normal.
 > Python one](https://github.com/github/gitignore/blob/main/Python.gitignore)
 > or using a [generator site](https://www.toptal.com/developers/gitignore).
 
-
 You should also add these two files:
 
 `.git_archival.txt`:

--- a/pages/developers/packaging.md
+++ b/pages/developers/packaging.md
@@ -196,6 +196,28 @@ run, that version will be forced, otherwise, it works as normal.
 > Python one](https://github.com/github/gitignore/blob/main/Python.gitignore)
 > or using a [generator site](https://www.toptal.com/developers/gitignore).
 
+
+You should also add these two files:
+
+`.git_archival.txt`:
+
+```text
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe)$
+ref-names: $Format:%D$
+```
+
+And `.gitattributes` (or add this line if you are already using this file):
+
+```text
+.git_archival.txt  export-subst
+```
+
+This will allow git archives (including the ones generated from GitHub) to also
+support versioning. This will only work with `setuptools_scm>=7`, which requires
+Python 3.7+ (though adding the files won't hurt older versions).
+
 ### Classic in-source versioning
 
 Recent versions of `setuptools` have improved in-source versioning. If you have

--- a/pages/developers/pep621.md
+++ b/pages/developers/pep621.md
@@ -24,7 +24,9 @@ is coming.
 >
 > These systems do not use or require `setup.py`, `setup.cfg`, or
 > `MANIFEST.in`. Those are for setuptools. Unless you are using
-> setuptools, of course, which still uses `MANIFEST.in`.
+> setuptools, of course, which still uses `MANIFEST.in`. You
+> can convert the old files using `pipx run hatch new --init`
+> or with [ini2toml](https://ini2toml.readthedocs.io/en/latest/).
 
 > ## Selecting a backend
 >
@@ -171,6 +173,26 @@ version.path = "src/<package>/__init__.py"
 ```
 
 (replace `<package>` with the package path).
+
+You should also add these two files:
+
+`.git_archival.txt`:
+
+```text
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe)$
+ref-names: $Format:%D$
+```
+
+And `.gitattributes` (or add this line if you are already using this file):
+
+```text
+.git_archival.txt  export-subst
+```
+
+This will allow git archives (including the ones generated from GitHub) to also
+support versioning.
 
 </details>
 

--- a/pages/developers/pep621.md
+++ b/pages/developers/pep621.md
@@ -181,7 +181,7 @@ You should also add these two files:
 ```text
 node: $Format:%H$
 node-date: $Format:%cI$
-describe-name: $Format:%(describe)$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$
 ref-names: $Format:%D$
 ```
 


### PR DESCRIPTION
Supported since `setuptools_scm` 7, Python 3.7+ only.
