### PR TITLE
feat: Add pyhf July 2022 use citations

### DIFF
--- a/pages/projusers/publications.md
+++ b/pages/projusers/publications.md
@@ -63,10 +63,13 @@ A list of publications citing the `pyhf` package or material using it is collect
 
 ### Experimental Particle Physics
 
+- [arXiv:2207.07476 [hep-ex]](https://arxiv.org/abs/2207.07476) - cites `pyhf`.
 - [arXiv:1706.01420 [hep-ex]](https://arxiv.org/abs/1706.01420) - cites `iminuit`.
 
 ### Particle Physics Phenomenology
 
+- [arXiv:2207.10756 [hep-ph]](https://arxiv.org/abs/2207.10756) - cites `pyhf`.
+- [arXiv:2206.14870 [hep-ph]](https://arxiv.org/abs/2206.14870) - cites `pyhf`.
 - [arXiv:2111.05868 [hep-ph]](https://arxiv.org/abs/2111.05868) - cites `pylhe`, Scikit-HEP project.
 - [arXiv:1907.10621 [hep-ph]](https://arxiv.org/abs/1907.10621) - cites `scikit-hep`, `uproot3`.
 - [arXiv:1712.05401 [hep-ph]](https://arxiv.org/abs/1712.05401) - cites `iminuit`.
@@ -95,6 +98,8 @@ A list of publications citing the `pyhf` package or material using it is collect
 
 ## PhD theses
 
+- [Audrey Kvam (Washington U.), Apr. 2022](https://inspirehep.net/literature/2086276), ATLAS experiment - cites `pyhf`.
+- [Lucas Santiago Borgna (University College London), Mar. 2022](https://inspirehep.net/literature/2085649), ATLAS experiment - cites `pyhf`.
 - [Dalila Salamani (Geneva U.), Dec. 2021](https://doi.org/10.13097/archive-ouverte/unige:158540), ATLAS experiment - cites the Scikit-HEP project.
 - [Srishti Bhasin (Bristol U.), Sep. 2021](https://inspirehep.net/literature/1982380), LHCb experiment - cites `scikit-hep`, Scikit-HEP project.
 - [Corin J. K. Hoad (Brunel U.), 2020](https://inspirehep.net/literature/1839082), CMS experiment - cites the Scikit-HEP project.


### PR DESCRIPTION
* Add pyhf use citation from 'Search for Events with Two Displaced Vertices from
Pair-Produced Neutral Long-Lived Particles Decaying to Hadronic Jets in the
Muon Spectrometer of the ATLAS Detector with Full Run 2 Data'.
   - c.f. https://inspirehep.net/literature/2086276
   - c.f. https://cds.cern.ch/record/2812260
   - Ph.D. dissertation of Audrey Kvam
* Add pyhf use citation from 'Search for pair production of Higgs Bosons
decaying to four bottom quarks with data collected by the ATLAS detector'.
   - c.f. https://inspirehep.net/literature/2085649
   - c.f. https://cds.cern.ch/record/2812193
   - Ph.D. dissertation of Lucas Santiago Borgna
* Add pyhf use citation from 'Signal region combination with full and simplified
likelihoods in MadAnalysis 5'.
   - c.f. https://inspirehep.net/literature/2103971
* Add pyhf use citation from 'Search for a dark leptophilic scalar produced in
association with τ+τ− pair in e+e− annihilation at center-of-mass energies near
10.58 GeV'.
   - Belle Collaboration paper
   - c.f. https://inspirehep.net/literature/2115280
* Add pyhf use citation from 'HighPT: A Tool for high-pT Drell-Yan Tails Beyond
the Standard Model'.
   - c.f. https://inspirehep.net/literature/2121076