### PR TITLE
fix: page order incorrect when testing just-the-docs 0.4.0 RC

### DIFF
--- a/pages/developers/coverage.md
+++ b/pages/developers/coverage.md
@@ -2,7 +2,7 @@
 layout: page
 title: "Code coverage"
 permalink: /developer/coverage
-nav_order: 4
+nav_order: 3
 parent: Developer information
 ---
 

--- a/pages/developers/intro.md
+++ b/pages/developers/intro.md
@@ -2,7 +2,7 @@
 layout: page
 title: Intro to development
 permalink: /developer/intro
-nav_order: 2
+nav_order: 1
 parent: Developer information
 ---
 

--- a/pages/developers/pytest.md
+++ b/pages/developers/pytest.md
@@ -2,7 +2,7 @@
 layout: page
 title: "Testing with pytest"
 permalink: /developer/pytest
-nav_order: 3
+nav_order: 2
 parent: Developer information
 ---
 


### PR DESCRIPTION
We have two items in the "order 4" slot.
