### PR TITLE
feat: Deprecate aghast as no longer supported or maintained

### DIFF
--- a/_data/projects/histogramming/aghast.yml
+++ b/_data/projects/histogramming/aghast.yml
@@ -4,6 +4,7 @@ description: Convert between histogram representations
 url: https://github.com/scikit-hep/aghast
 # docs: https://aghast.readthedocs.io/
 # affiliated: set to true for affiliated packages
+deprecated: true
 # repo: only if different from url
 badges:
   pypi: aghast


### PR DESCRIPTION
* c.f. https://github.com/scikit-hep/aghast

Following up on [this Gitter discussion](https://gitter.im/Scikit-HEP/community?at=6357ea04aa210536d62a0105).

Closes #280.