### PR TITLE
feat: Add pyhf NumFOCUS affiliated project and pyjet archive news

### DIFF
--- a/pages/news.md
+++ b/pages/news.md
@@ -5,7 +5,11 @@ permalink: /news
 nav_order: 2
 ---
 
+**January 2023:** Package `pyjet` archived.
+
 **January 2023:** Package `numpythia` deprecated and archived.
+
+**December 2022:** `pyhf` accepted as an affiliated project of NumFOCUS.
 
 **December 2022:** Major releases `awkward` 2.0.0 and `uproot` 5.0.0.
 

--- a/pages/news.md
+++ b/pages/news.md
@@ -5,11 +5,9 @@ permalink: /news
 nav_order: 2
 ---
 
-**January 2023:** Package `pyjet` archived.
+**January 2023:** Package `numpythia` deprecated and archived. Package `pyjet` archived.
 
-**January 2023:** Package `numpythia` deprecated and archived.
-
-**December 2022:** `pyhf` accepted as an affiliated project of NumFOCUS.
+**December 2022:** `pyhf` accepted as an affiliated project of [NumFOCUS][].
 
 **December 2022:** Major releases `awkward` 2.0.0 and `uproot` 5.0.0.
 
@@ -187,5 +185,6 @@ Eduardo Rodrigues, Jim Pivarski and others.
 [iris-hep institute]: https://iris-hep.org/
 [km3net experiment]: https://www.km3net.org/
 [lhcb experiment]: http://lhcb.web.cern.ch/
+[numfocus]: https://numfocus.org/
 [pdg]: https://pdg.lbl.gov/
 [online particle physics information]: https://github.com/particledatagroup/hep-resources


### PR DESCRIPTION
* pyhf was accepted as an Affiliated Project of NumFOCUS in December 2022.
  - c.f. https://github.com/pyhf/numfocus-affiliate-project-application/pull/2
* pyjet was archived in January 2023.
   - c.f. https://github.com/scikit-hep/pyjet/pull/84