### PR TITLE
fix: drop explicit B9 addition

### DIFF
--- a/pages/developers/style.md
+++ b/pages/developers/style.md
@@ -160,7 +160,7 @@ Ruff is configured in your `pyproject.toml`. Here's an example:
 [tool.ruff]
 select = [
   "E", "F", "W", # flake8
-  "B", "B904",   # flake8-bugbear
+  "B",           # flake8-bugbear
   "I",           # isort
   "ARG",         # flake8-unused-arguments
   "C4",          # flake8-comprehensions


### PR DESCRIPTION
Ruff doesn't seem to treat B9xx specially, so this doesn't do anything.