### PR TITLE
fix: remove license setting

### DIFF
--- a/pages/developers/pep621.md
+++ b/pages/developers/pep621.md
@@ -90,7 +90,6 @@ authors = [
 maintainers = [
   { name = "Scikit-HEP", email = "scikit-hep-admins@googlegroups.com" },
 ]
-license = { file = "LICENSE" }
 requires-python = ">=3.7"
 
 dependencies = [


### PR DESCRIPTION
This is not even used by some backends, and is not the correct way to set a standard license, it's only for modified licenses. Standard ones must be specified via classifiers.