### PR TITLE
docs: Add pylhe use citation from BSM reach of four top production at LHC paper

### DIFF
--- a/pages/projusers/publications.md
+++ b/pages/projusers/publications.md
@@ -76,6 +76,7 @@ A list of publications citing the `pyhf` package or material using it is collect
 
 ### Particle Physics Phenomenology
 
+- [arXiv:2302.08281 [hep-ph]](https://arxiv.org/abs/2302.08281) - cites `pylhe`.
 - [arXiv:2210.16305 [hep-ph]](https://arxiv.org/abs/2210.16305) - cites the Scikit-HEP project.
 - [arXiv:2207.10756 [hep-ph]](https://arxiv.org/abs/2207.10756) - cites `pyhf`.
 - [arXiv:2207.04137 [hep-ph]](https://arxiv.org/abs/2207.04137) - cites `Particle`, `pyhepmc`, Scikit-HEP project.


### PR DESCRIPTION
Add `pylhe` use citation from [On the BSM reach of four top production at the LHC](https://inspirehep.net/literature/2633019) by Anisha, Oliver Atkinson, Akanksha Bhardwaj, Christoph Englert, Wrishik Naskar, Panagiotis Stylianou.

This was noticed by @lukasheinrich over in https://github.com/scikit-hep/pylhe/issues/181#issuecomment-1509207141.