### PR TITLE
fix: issue with latest just-the-docs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,7 +12,7 @@ github_username: scikit-hep
 # Build settings
 markdown: kramdown
 # Local: theme: "just-the-docs"
-remote_theme: "pmarsceill/just-the-docs"
+remote_theme: "just-the-docs/just-the-docs@v0.4.2"
 plugins:
   - jekyll-feed
 


### PR DESCRIPTION
0.5.0 breaks us. I think it might be due the base-url being unset. ~~I might try that first.~~ We don't have a baseurl on `scikit-hep.org`, so don't think there's something I can set here.