### PR TITLE
News - awkward accepted as an affiliated project of NumFOCUS

### DIFF
--- a/pages/news.md
+++ b/pages/news.md
@@ -5,6 +5,8 @@ permalink: /news
 nav_order: 2
 ---
 
+**March 2023:** `awkward` accepted as an affiliated project of [NumFOCUS][].
+
 **January 2023:** Package `numpythia` deprecated and archived. Package `pyjet` archived.
 
 **December 2022:** `pyhf` accepted as an affiliated project of [NumFOCUS][].


### PR DESCRIPTION
* awkward was accepted as an Affiliated Project of NumFOCUS in March 2023.

@jpivarski, @matthewfeickert, can you confirm the date?