### PR TITLE
fix: link color issue

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,19 +32,19 @@ repos:
     hooks:
       - id: codespell
         exclude: (^Gemfile\.lock|\.svg)$
-        args: ["-L", "hist,sur,nd,theses,ser,HEP,hep"]
+        args: ["-L", "hist,sur,nd,theses,ser"]
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v4.0.0-alpha.8"
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: "v3.4.2"
     hooks:
       - id: prettier
-        types_or: [yaml, markdown, html, css, scss, javascript, json]
+        types_or: [yaml, markdown, html, css, javascript, json]
 
   - repo: https://github.com/adamchainz/blacken-docs
     rev: 1.19.1
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==22.8.0]
+        additional_dependencies: [black~=25.0]
 
   - repo: local
     hooks:

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -28,19 +28,19 @@
       /* document.documentElement.style.display = 'none'; */
       document.head.insertAdjacentHTML(
         'beforeend',
-        '<link rel="stylesheet" href="{{ '/assets/css/just-the-docs-default.css' | relative_url }}" onload="document.documentElement.style.display = \'\'">',
+        '<link rel="stylesheet" href="{{ '/assets/css/just-the-docs-skhep.css' | relative_url }}" onload="document.documentElement.style.display = \'\'">',
       );
     }
   </script>
 
   <link
     rel="stylesheet"
-    href="{{ '/assets/css/just-the-docs-dark.css' | relative_url }}"
+    href="{{ '/assets/css/just-the-docs-darkskhep.css' | relative_url }}"
     media="(prefers-color-scheme: dark)"
   />
   <link
     rel="stylesheet"
-    href="{{ '/assets/css/just-the-docs-light.css' | relative_url }}"
+    href="{{ '/assets/css/just-the-docs-skhep.css' | relative_url }}"
     media="(prefers-color-scheme: light)"
   />
 

--- a/_sass/color_schemes/darkskhep.scss
+++ b/_sass/color_schemes/darkskhep.scss
@@ -1,0 +1,3 @@
+@import "./color_schemes/dark";
+
+$link-color: #7092be;

--- a/assets/css/just-the-docs-darkskhep.scss
+++ b/assets/css/just-the-docs-darkskhep.scss
@@ -1,0 +1,3 @@
+---
+---
+{% include css/just-the-docs.scss.liquid color_scheme="darkskhep" %}

--- a/assets/css/just-the-docs-skhep.scss
+++ b/assets/css/just-the-docs-skhep.scss
@@ -1,0 +1,3 @@
+---
+---
+{% include css/just-the-docs.scss.liquid color_scheme="skhep" %}


### PR DESCRIPTION
Link color was not being set, since we were overriding the theme setting infrustructure to get light/dark mode switching. I've followed https://just-the-docs.com/docs/customization/#define-a-custom-scheme and integrated the theme color setting with our custom infrustructure.
